### PR TITLE
Systemd tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 *   Rename handlers to use more specific role related naming and prevent namespace collision issues.
+*   Add a `nginx_app_protect_service_modify` variable to revert a breaking change introduced in 0.3.0 where timeouts would not be set by default.
 
 ## 0.3.0 (September 21, 2020)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,8 @@ nginx_app_protect_start: true
 
 # Increase NGINX service timeout to accommodate ruleset loading from default 90s.
 # Default is commented out.
-# nginx_app_protect_timeout: 180
+nginx_app_protect_service_modify: true
+nginx_app_protect_timeout: 180
 
 # Creates basic configuration files and enables NGINX App Protect on the target host
 nginx_app_protect_configure: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: (Handler - NGINX App Protect) Systemd daemon-reload
-  systemd:
-    daemon_reload: true
-
 - name: (Handler - NGINX App Protect) Check NGINX
   command: nginx -t
   register: config

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: (Handler - NGINX App Protect) Systemd daemon-reload
+  systemd:
+    daemon_reload: true
+
 - name: (Handler - NGINX App Protect) Check NGINX
   command: nginx -t
   register: config

--- a/tasks/install/install-app-protect.yml
+++ b/tasks/install/install-app-protect.yml
@@ -29,6 +29,7 @@
         owner: root
         group: root
         mode: 0644
+      notify: (Handler - NGINX App Protect) Systemd daemon-reload
   when: nginx_app_protect_service_modify | bool
 
 - name: Set up NGINX App Protect repositories

--- a/tasks/install/install-app-protect.yml
+++ b/tasks/install/install-app-protect.yml
@@ -29,7 +29,6 @@
         owner: root
         group: root
         mode: 0644
-      notify: (Handler - NGINX App Protect) Systemd daemon-reload
   when: nginx_app_protect_service_modify | bool
 
 - name: Set up NGINX App Protect repositories

--- a/tasks/install/install-app-protect.yml
+++ b/tasks/install/install-app-protect.yml
@@ -14,6 +14,24 @@
     quiet: true
   when: nginx_plus_version is defined
 
+- name: Modify NGINX Plus service
+  block:
+    - name: Create override for NGINX Plus service
+      file:
+        path: /etc/systemd/system/nginx.service.d
+        state: directory
+        mode: 0755
+
+    - name: Increase timeout for NGINX Plus service
+      template:
+        src: nginx.service.override.conf.j2
+        dest: /etc/systemd/system/nginx.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: (Handler - NGINX App Protect) Systemd daemon-reload
+  when: nginx_app_protect_service_modify | bool
+
 - name: Set up NGINX App Protect repositories
   include_tasks: "{{ role_path }}/tasks/install/setup-{{ ansible_facts['os_family'] | lower }}.yml"
   when: nginx_app_protect_state != "absent"
@@ -37,21 +55,3 @@
     state: "{{ nginx_app_protect_state }}"
   when: nginx_app_protect_install_threat_campaigns | bool
   notify: (Handler - NGINX App Protect) Run NGINX
-
-- name: Modify NGINX Plus service
-  block:
-    - name: Create override for NGINX Plus service
-      file:
-        path: /etc/systemd/system/nginx.service.d
-        state: directory
-        mode: 0755
-
-    - name: Increase timeout for NGINX Plus service
-      template:
-        src: nginx.service.override.conf.j2
-        dest: /etc/systemd/system/nginx.service.d/override.conf
-        owner: root
-        group: root
-        mode: 0644
-      notify: (Handler - NGINX App Protect) Systemd daemon-reload
-  when: nginx_app_protect_timeout is defined

--- a/tasks/install/install-app-protect.yml
+++ b/tasks/install/install-app-protect.yml
@@ -14,24 +14,6 @@
     quiet: true
   when: nginx_plus_version is defined
 
-- name: Modify NGINX Plus service
-  block:
-    - name: Create override for NGINX Plus service
-      file:
-        path: /etc/systemd/system/nginx.service.d
-        state: directory
-        mode: 0755
-
-    - name: Increase timeout for NGINX Plus service
-      template:
-        src: nginx.service.override.conf.j2
-        dest: /etc/systemd/system/nginx.service.d/override.conf
-        owner: root
-        group: root
-        mode: 0644
-      notify: (Handler - NGINX App Protect) Systemd daemon-reload
-  when: nginx_app_protect_service_modify | bool
-
 - name: Set up NGINX App Protect repositories
   include_tasks: "{{ role_path }}/tasks/install/setup-{{ ansible_facts['os_family'] | lower }}.yml"
   when: nginx_app_protect_state != "absent"
@@ -55,3 +37,21 @@
     state: "{{ nginx_app_protect_state }}"
   when: nginx_app_protect_install_threat_campaigns | bool
   notify: (Handler - NGINX App Protect) Run NGINX
+
+- name: Modify NGINX Plus service
+  block:
+    - name: Create override for NGINX Plus service
+      file:
+        path: /etc/systemd/system/nginx.service.d
+        state: directory
+        mode: 0755
+
+    - name: Increase timeout for NGINX Plus service
+      template:
+        src: nginx.service.override.conf.j2
+        dest: /etc/systemd/system/nginx.service.d/override.conf
+        owner: root
+        group: root
+        mode: 0644
+      notify: (Handler - NGINX App Protect) Systemd daemon-reload
+  when: nginx_app_protect_service_modify | bool


### PR DESCRIPTION
### Proposed changes
Add a `nginx_app_protect_service_modify` variable to revert a breaking change introduced in 0.3.0 where timeouts would not be set by default.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
