### PR TITLE
Tweak handler to have a default state of restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 *   Rename handlers to use more specific role related naming and prevent namespace collision issues.
+*   Set NGINX handler to `state: restasted` to prevent some compatibility issues when NGINX App Protect is installed on an instance already running NGINX beforehand.
 
 ## 0.3.0 (September 21, 2020)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,20 +3,7 @@
   systemd:
     daemon_reload: true
 
-- name: (Handler - NGINX App Protect) Check NGINX
-  command: nginx -t
-  register: config
-  ignore_errors: true
-  listen: (Handler - NGINX App Protect) Run NGINX
-
-- name: (Handler - NGINX App Protect) Print NGINX error if syntax check fails
-  debug:
-    var: config.stderr_lines
-  failed_when: config.rc != 0
-  when: config.rc != 0
-  listen: (Handler - NGINX App Protect) Run NGINX
-
-- name: (Handler - NGINX App Protect) Start/reload NGINX
+- name: (Handler - NGINX App Protect) Restart NGINX
   service:
     name: nginx
     state: restarted
@@ -24,4 +11,18 @@
   when:
     - nginx_app_protect_start | bool
     - not ansible_check_mode | bool
+  listen: (Handler - NGINX App Protect) Run NGINX
+
+- name: (Handler - NGINX App Protect) Check NGINX
+  command: nginx -t
+  register: config
+  ignore_errors: true
+  changed_when: false
+  listen: (Handler - NGINX App Protect) Run NGINX
+
+- name: (Handler - NGINX App Protect) Print NGINX error if syntax check fails
+  debug:
+    var: config.stderr_lines
+  failed_when: config.rc != 0
+  when: config.rc != 0
   listen: (Handler - NGINX App Protect) Run NGINX

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,7 @@
 - name: (Handler - NGINX App Protect) Start/reload NGINX
   service:
     name: nginx
-    state: reloaded
+    state: restarted
     enabled: true
   when:
     - nginx_app_protect_start | bool


### PR DESCRIPTION
### Proposed changes
This prevents some compatibility issues when NGINX App Protect is installed on an instance running NGINX beforehand.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
