### PR TITLE
Fix occasional update_cache idempotence failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 *   Rename handlers to use more specific role related naming and prevent namespace collision issues.
 *   Add a `nginx_app_protect_service_modify` variable to revert a breaking change introduced in 0.3.0 where timeouts would not be set by default.
 *   Set NGINX handler to `state: restarted` to prevent some compatibility issues when NGINX App Protect is installed on an instance already running NGINX beforehand.
+*   Using `update_cache: true` by itself in the `apt` module is not always idempotent. Moved the NGINX App Protect installation task to a corresponding `apt` or `yum` module to avoid this scenario.
 
 ## 0.3.0 (September 21, 2020)
 

--- a/tasks/install/install-app-protect.yml
+++ b/tasks/install/install-app-protect.yml
@@ -14,15 +14,8 @@
     quiet: true
   when: nginx_plus_version is defined
 
-- name: Set up NGINX App Protect repositories
-  include_tasks: "{{ role_path }}/tasks/install/setup-{{ ansible_facts['os_family'] | lower }}.yml"
-  when: nginx_app_protect_state != "absent"
-
 - name: Install NGINX App Protect
-  package:
-    name: "app-protect{{ nginx_app_protect_version | default('') }}"
-    state: "{{ nginx_app_protect_state }}"
-  notify: (Handler - NGINX App Protect) Run NGINX
+  include_tasks: "{{ role_path }}/tasks/install/install-{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Install latest NGINX App Protect signatures
   package:

--- a/tasks/install/install-debian.yml
+++ b/tasks/install/install-debian.yml
@@ -40,6 +40,9 @@
     update_cache: false
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
 
-- name: (Debian/Ubuntu) Update the apt cache
+- name: (Debian/Ubuntu) Install NGINX App Protect
   apt:
+    name: "app-protect{{ nginx_app_protect_version | default('') }}"
+    state: "{{ nginx_app_protect_state }}"
     update_cache: true
+  notify: (Handler - NGINX App Protect) Run NGINX

--- a/tasks/install/install-redhat.yml
+++ b/tasks/install/install-redhat.yml
@@ -20,3 +20,10 @@
     enabled: true
     gpgcheck: true
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
+
+- name: (CentOS/RHEL) Install NGINX App Protect
+  yum:
+    name: "app-protect{{ nginx_app_protect_version | default('') }}"
+    state: "{{ nginx_app_protect_state }}"
+    update_cache: true
+  notify: (Handler - NGINX App Protect) Run NGINX


### PR DESCRIPTION
### Proposed changes
Using `update_cache: true` by itself in the `apt` module is not always idempotent. Moved the NGINX App Protect installation task to a corresponding `apt` or `yum` module to avoid this scenario.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
