### PR TITLE
Add default license vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.4.1 (Novemeber 17, 2020)
+## 0.4.2 (Unreleased)
+
+BUG FIXES:
+
+Specify default values for the `nginx_app_protect_license` dictionary.
+
+## 0.4.1 (November 17, 2020)
 
 ENHANCEMENTS:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,12 @@ nginx_app_protect_install_threat_campaigns: true
 #   nginx_plus: https://cs.nginx.com/static/keys/nginx_signing.key
 #   security_updates: https://cs.nginx.com/static/keys/app-protect-security-updates.key
 
+# Location of your NGINX App Protect license in your local machine.
+# Default is the files folder within the NGINX Ansible role.
+nginx_app_protect_license:
+  certificate: license/nginx-repo.crt
+  key: license/nginx-repo.key
+
 # Set up NGINX App Protect license (cert/key) before installation.
 # Default is true.
 nginx_app_protect_setup_license: true


### PR DESCRIPTION
### Proposed changes
Specify default values for the `nginx_app_protect_license` dictionary to address issue #41 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [X] I have checked that all Molecule tests pass after adding my changes
-   [X] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
