### PR TITLE
Update Ansible collections

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -40,10 +40,6 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
-      - name: Uninstall Ansible community distribution (temporary)
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        run: pip3 uninstall -y ansible
-
       - name: Run Molecule tests
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: molecule test -s ${{ matrix.scenario }}

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 2.3.0
+    version: 2.5.1
   - name: ansible.posix
     version: 1.2.0
   - name: community.docker
-    version: 1.4.0
+    version: 1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ENHANCEMENTS:
 
-Update Ansible base to `2.10.8`, Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
+*   Update Ansible base to `2.10.8`, Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
+*   Update the Ansible `community.general` collection to `2.5.1` and `community.docker` collection to `1.5.0`.
 
 ## 0.4.3 (April 6, 2020)
 


### PR DESCRIPTION
### Proposed changes
Update the Ansible `community.general` collection to `2.5.1` and `community.docker` collection to `1.5.0`. And while at it, remove the temporary GitHub actions step to uninstall the Ansible community distribution (it's no longer an Ansible Lint dependency).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
