### PR TITLE
Change default NGINX App Protect conf path for 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ ENHANCEMENTS:
 
 Update Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
 
+BREAKING CHANGES:
+
+Changing the default policy directory from `/etc/nginx` to `/etc/app_protect/conf` to align with this change introduced in App Protect 3.2.
+
 ## 0.4.3 (April 6, 2020)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 ENHANCEMENTS:
 
-Update Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
-
-BREAKING CHANGES:
-
-Changing the default policy directory from `/etc/nginx` to `/etc/app_protect/conf` to align with this change introduced in App Protect 3.2.
+*   Update Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
+*   Changing the default policy directory from `/etc/nginx` to `/etc/app_protect/conf` to align with this change introduced in App Protect 3.2.
 
 ## 0.4.3 (April 6, 2020)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,7 +75,7 @@ nginx_app_protect_security_policy_template_enable: true
 nginx_app_protect_security_policy_template:
   template_file: app-protect-security-policy.j2
   out_file_name: app-protect-security-policy.json
-  out_file_location: /etc/nginx/
+  out_file_location: /etc/app_protect/conf/
 # possible values: transparent, blocking
 nginx_app_protect_security_policy_enforcement_mode: transparent
 
@@ -85,7 +85,7 @@ nginx_app_protect_log_policy_template_enable: true
 nginx_app_protect_log_policy_template:
   template_file: app-protect-log-policy.j2
   out_file_name: app-protect-log-policy.json
-  out_file_location: /etc/nginx/
+  out_file_location: /etc/app_protect/conf/
 # possible values: all, illegal, blocked
 nginx_app_protect_log_policy_filter_request_type: all
 
@@ -95,7 +95,7 @@ nginx_app_protect_conf_template_enable: false
 nginx_app_protect_conf_template:
   template_file: nginx.conf.j2
   out_file_name: nginx.conf
-  out_file_location: /etc/nginx/
+  out_file_location: /etc/app_protect/conf/
 nginx_app_protect_demo_workload_protocol: http://
 nginx_app_protect_demo_workload_host: 10.1.1.1:8080
 nginx_app_protect_log_policy_syslog_target: 127.0.0.1:514  # DEPRECATED -- use nginx_app_protect_log_policy_target instead
@@ -104,9 +104,9 @@ nginx_app_protect_log_policy_target: "syslog:server={{ nginx_app_protect_log_pol
 # Copy local NGINX App Protect security policy to host
 nginx_app_protect_security_policy_file_enable: false
 nginx_app_protect_security_policy_file_src: files/config/security-policy.json
-nginx_app_protect_security_policy_file_dest: /etc/nginx/security-policy.json
+nginx_app_protect_security_policy_file_dest: /etc/app_protect/conf/security-policy.json
 
 # Copy local NGINX App Protect log policy to host
 nginx_app_protect_log_policy_file_enable: false
 nginx_app_protect_log_policy_file_src: files/config/log-policy.json
-nginx_app_protect_log_policy_file_dest: /etc/nginx/log-policy.json
+nginx_app_protect_log_policy_file_dest: /etc/app_protect/conf/log-policy.json

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,7 +95,7 @@ nginx_app_protect_conf_template_enable: false
 nginx_app_protect_conf_template:
   template_file: nginx.conf.j2
   out_file_name: nginx.conf
-  out_file_location: /etc/app_protect/conf/
+  out_file_location: /etc/nginx/
 nginx_app_protect_demo_workload_protocol: http://
 nginx_app_protect_demo_workload_host: 10.1.1.1:8080
 nginx_app_protect_log_policy_syslog_target: 127.0.0.1:514  # DEPRECATED -- use nginx_app_protect_log_policy_target instead

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -47,12 +47,12 @@
 
     - name: Check that the security policy exists
       stat:
-        path: /etc/nginx/app-protect-security-policy.json
+        path: /etc/app_protect/conf/app-protect-security-policy.json
       register: stat_result
       failed_when: not stat_result.stat.exists
 
     - name: Check that the log policy exists
       stat:
-        path: /etc/nginx/app-protect-log-policy.json
+        path: /etc/app_protect/conf/app-protect-log-policy.json
       register: stat_result
       failed_when: not stat_result.stat.exists


### PR DESCRIPTION
### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [X] I have added Molecule tests that prove my fix is effective or that my feature works
-   [X] I have checked that all Molecule tests pass after adding my changes
-   [X] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
