### PR TITLE
Replace Ansible base with Ansible core

### DIFF
--- a/.github/workflows/requirements/requirements_galaxy.txt
+++ b/.github/workflows/requirements/requirements_galaxy.txt
@@ -1,1 +1,1 @@
-ansible-base==2.10.9
+ansible-core==2.11.1

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,4 +1,4 @@
-ansible-base==2.10.9
+ansible-core==2.11.1
 Jinja2==3.0.0
 ansible-lint==5.0.8
 yamllint==1.26.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ ENHANCEMENTS:
 *   Changing the default policy directory from `/etc/nginx` to `/etc/app_protect/conf` to align with this change introduced in App Protect 3.2.
 *   Update Ansible base to `2.10.8`, Ansible Lint to `5.0.7`, yamllint to `1.26.1` and Docker Python SDK to `5.0.0`.
 *   Update the Ansible `community.general` collection to `3.0.2` and `community.docker` collection to `1.6.0`.
+*   Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
 
 ## 0.4.3 (April 6, 2020)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This role installs and configures NGINX App Protect (WAF) for NGINX Plus on your
 
 ### Ansible
 
-*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible base (bigger than `2.10`) and Ansible (bigger than `2.9.10`).
+*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible core (above `2.11`) and Ansible (above `2.9.10`).
 *   When using Ansible base, you will also need to install the following collections:
     ```yaml
     ---


### PR DESCRIPTION
### Proposed changes
Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
