### PR TITLE
Update `nginx` role requirement in Molecule tests to `0.20.0`

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,2 @@
 ---
-exclude_paths:
-  - ~/.cache
+offline: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 *   Update GitHub actions to add a workflow dispatch option.
 *   Update the Ansible `community.general` collection to `3.1.0` and `community.docker` collection to `1.6.1`.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
+*   Update `nginx` role requirement in Molecule tests to `0.20.0`.
 
 ## 0.5.0 (May 12, 2020)
 

--- a/molecule/advanced/requirements.yml
+++ b/molecule/advanced/requirements.yml
@@ -1,6 +1,6 @@
 ---
 roles:
+  - name: nginxinc.nginx
+    version: 0.20.0
   - name: robertdebock.rsyslog
     version: 3.2.0
-  - name: nginxinc.nginx
-    version: 0.19.2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.19.2
+    version: 0.20.0

--- a/molecule/specific-version/molecule.yml
+++ b/molecule/specific-version/molecule.yml
@@ -2,7 +2,7 @@
 dependency:
   name: galaxy
   options:
-    role-file: molecule/default/requirements.yml
+    role-file: molecule/specific-version/requirements.yml
 driver:
   name: docker
 lint: |

--- a/molecule/specific-version/requirements.yml
+++ b/molecule/specific-version/requirements.yml
@@ -1,4 +1,4 @@
 ---
 roles:
   - name: nginxinc.nginx
-    version: 0.19.2
+    version: 0.20.0


### PR DESCRIPTION
### Proposed changes
Update `nginx` role requirement in Molecule tests to `0.20.0` and change the `.ansible-lint` config file to avoid installing third party roles as part of the `prerun` process.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
