### PR TITLE
Add 'nginx_app_protect_manage_repo' feature flag and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.1 (Unreleased)
 
+FEATURES:
+
+Add a `nginx_app_protect_manage_repo` feature flag which can be used to disable NGINX App Protect repo management by this role.
+
 ENHANCEMENTS:
 
 *   Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
@@ -9,7 +13,6 @@ ENHANCEMENTS:
 *   Update the Ansible `community.general` collection to `3.1.0` and `community.docker` collection to `1.6.1`.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
 *   Update `nginx` role requirement in Molecule tests to `0.20.0`.
-*   Add a `nginx_app_protect_manage_repo` feature flag which can be used to disable NGINX App Protect repo management by this role.
 
 ## 0.5.0 (May 12, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ ENHANCEMENTS:
 *   Update the Ansible `community.general` collection to `3.1.0` and `community.docker` collection to `1.6.1`.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
 *   Update `nginx` role requirement in Molecule tests to `0.20.0`.
-*   Add a `nginx_app_protect_manage_repo` feature flag which can be used to disable Nginx App Protect repo management by this role.
+*   Add a `nginx_app_protect_manage_repo` feature flag which can be used to disable NGINX App Protect repo management by this role.
 
 ## 0.5.0 (May 12, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 *   Update the Ansible `community.general` collection to `3.1.0` and `community.docker` collection to `1.6.1`.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
 *   Update `nginx` role requirement in Molecule tests to `0.20.0`.
+*   Add a `nginx_app_protect_manage_repo` feature flag which can be used to disable Nginx App Protect repo management by this role.
 
 ## 0.5.0 (May 12, 2020)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,12 @@ nginx_app_protect_install_threat_campaigns: true
 #   nginx_plus: https://cs.nginx.com/static/keys/nginx_signing.key
 #   security_updates: https://cs.nginx.com/static/keys/app-protect-security-updates.key
 
+# Specify whether or not you want to manage the Nginx App Protect repositories.
+# Using 'true' will manage Nginx App Protect repositories.
+# Using 'false' will not manage the Nginx App Protect repositories, allowing them to be managed through other means.
+# Default is true
+nginx_app_protect_manage_repo: true
+
 # (Optional) Specify repository for NGINX Plus.
 # Defaults are the official NGINX repositories.
 # nginx_plus_repository: deb [arch=amd64] https://pkgs.nginx.com/plus/debian buster nginx-plus

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,9 +35,9 @@ nginx_app_protect_install_threat_campaigns: true
 #   nginx_plus: https://cs.nginx.com/static/keys/nginx_signing.key
 #   security_updates: https://cs.nginx.com/static/keys/app-protect-security-updates.key
 
-# Specify whether or not you want to manage the Nginx App Protect repositories.
-# Using 'true' will manage Nginx App Protect repositories.
-# Using 'false' will not manage the Nginx App Protect repositories, allowing them to be managed through other means.
+# Specify whether or not you want to manage the NGINX App Protect repositories.
+# Using 'true' will manage NGINX App Protect repositories.
+# Using 'false' will not manage the NGINX App Protect repositories, allowing them to be managed through other means.
 # Default is true
 nginx_app_protect_manage_repo: true
 

--- a/tasks/install/install-alpine.yml
+++ b/tasks/install/install-alpine.yml
@@ -5,6 +5,7 @@
     insertafter: EOF
     line: "{{ nginx_plus_repository | default(nginx_plus_default_repository_alpine) }}"
     state: "{{ nginx_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (Alpine Linux) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect repository
   lineinfile:
@@ -12,6 +13,7 @@
     insertafter: EOF
     line: "{{ nginx_app_protect_repository | default(nginx_app_protect_default_repository_alpine) }}"
     state: "{{ nginx_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (Alpine Linux) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect security updates repository
   lineinfile:
@@ -19,8 +21,9 @@
     insertafter: EOF
     line: "{{ nginx_app_protect_security_updates_repository | default(nginx_app_protect_security_updates_default_repository_alpine) }}"
     state: "{{ nginx_license_status | default ('present') }}"
-  when: nginx_app_protect_install_signatures | bool
-        or nginx_app_protect_install_threat_campaigns | bool
+  when:
+    - (nginx_app_protect_install_signatures | bool) or (nginx_app_protect_install_threat_campaigns | bool)
+    - nginx_app_protect_manage_repo | bool
 
 - name: (Alpine Linux) Install NGINX App Protect
   apk:

--- a/tasks/install/install-debian.yml
+++ b/tasks/install/install-debian.yml
@@ -45,6 +45,7 @@
     mode: 0644
     update_cache: false
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (Debian/Ubuntu) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect repository
   apt_repository:
@@ -53,6 +54,7 @@
     mode: 0644
     update_cache: false
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (Debian/Ubuntu) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect security updates repository
   apt_repository:
@@ -61,8 +63,9 @@
     mode: 0644
     update_cache: false
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
-  when: nginx_app_protect_install_signatures | bool
-        or nginx_app_protect_install_threat_campaigns | bool
+  when:
+    - (nginx_app_protect_install_signatures | bool) or (nginx_app_protect_install_threat_campaigns | bool)
+    - nginx_app_protect_manage_repo | bool
 
 - name: (Debian/Ubuntu) Install NGINX App Protect
   apt:

--- a/tasks/install/install-redhat.yml
+++ b/tasks/install/install-redhat.yml
@@ -20,6 +20,7 @@
     enabled: true
     gpgcheck: true
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect security updates repository
   yum_repository:
@@ -31,8 +32,9 @@
     enabled: true
     gpgcheck: true
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
-  when: nginx_app_protect_install_signatures | bool
-        or nginx_app_protect_install_threat_campaigns | bool
+  when:
+    - (nginx_app_protect_install_signatures | bool) or (nginx_app_protect_install_threat_campaigns | bool)
+    - nginx_app_protect_manage_repo | bool
 
 - name: (CentOS/RHEL) Install NGINX App Protect
   yum:


### PR DESCRIPTION
### Proposed changes

This change adds a `nginx_app_protect_manage_repo` boolean which can be used to disable Nginx App Protect repo management by this role.

This feature flag addresses edge-cases where Nginx' App Protect repositories are managed by other means and should not be configured by this role in order to install Nginx App Protect. The default behavior of the role is unaltered.

### Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)

Sidenote on Molecule tests, as a test for setting `nginx_app_protect_manage_repo` to `false`  would effectively require current tests to be disabled, and as the default behavior is not altered, no additional tests have been added. 