### PR TITLE
nginx_app_protect_manage_repo flag for RHEL NGINX Plus repository

### DIFF
--- a/tasks/install/install-redhat.yml
+++ b/tasks/install/install-redhat.yml
@@ -9,6 +9,7 @@
     enabled: true
     gpgcheck: true
     state: "{{ nginx_app_protect_license_status | default ('present') }}"
+  when: nginx_app_protect_manage_repo | bool
 
 - name: (CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect repository
   yum_repository:


### PR DESCRIPTION
### Proposed changes

Extends PR #108, setting the `nginx_app_protect_manage_repo` flag on the RHEL _NGINX Plus repository_ task which was erroneously omitted from that PR.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
