### PR TITLE
Always update NAP dependencies to the latest available version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2 (Unreleased)
+
+ENHANCEMENTS:
+
+Move non NGINX specific dependencies from the role into the Molecule Dockerfile.
+
+BUG FIXES:
+
+Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+
 ## 0.6.1 (September 30, 2021)
 
 KNOWN ISSUES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ENHANCEMENTS:
 
-Move non NGINX specific dependencies from the role into the Molecule Dockerfile.
+Move non NGINX App Protect specific dependencies from the role into the Molecule Dockerfile.
 
 BUG FIXES:
 
-Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+Always update NGINX App Protect dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
 
 ## 0.6.1 (September 30, 2021)
 

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -17,7 +17,7 @@ ENV {{ var }} {{ value }}
 RUN \
   if [ $(command -v apt-get) ]; then \
     apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash ca-certificates curl iproute2 python-apt python3 python3-apt procps sudo systemd systemd-sysv vim \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash curl dirmngr iproute2 python3 python3-apt procps sudo systemd systemd-sysv vim \
     && apt-get clean; \
   elif [ $(command -v dnf) ]; then \
     dnf makecache \
@@ -25,7 +25,7 @@ RUN \
     && dnf clean all; \
   elif [ $(command -v yum) ]; then \
     yum makecache fast \
-    && yum install -y bash iproute sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl initscripts \
+    && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
     && yum clean all; \
   elif [ $(command -v zypper) ]; then \
@@ -34,10 +34,10 @@ RUN \
     && zypper clean -a; \
   elif [ $(command -v apk) ]; then \
     apk update \
-    && apk add --no-cache bash ca-certificates curl openrc python3 sudo vim; \
+    && apk add --no-cache bash curl openrc python3 sudo vim; \
     echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
   elif [ $(command -v xbps-install) ]; then \
     xbps-install -Syu \
-    && xbps-install -y bash ca-certificates iproute2 python3 sudo vim \
+    && xbps-install -y bash iproute2 python3 sudo vim \
     && xbps-remove -O; \
   fi

--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -3,6 +3,7 @@
   apk:
     name: "{{ nginx_app_protect_alpine_dependencies }}"
     update_cache: true
+    state: latest  # noqa package-latest
   ignore_errors: "{{ ansible_check_mode }}"
   when: ansible_os_family == "Alpine"
 
@@ -10,11 +11,14 @@
   apt:
     name: "{{ nginx_app_protect_debian_dependencies }}"
     update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_os_family == "Debian"
 
 - name: (CentOS) Install package dependencies
   yum:
     name: "{{ nginx_app_protect_centos_dependencies }}"
+    update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_distribution == "CentOS"
 
 - name: (RHEL) Install dependencies
@@ -22,6 +26,8 @@
     - name: (RHEL) Install package dependencies
       yum:
         name: "{{ nginx_app_protect_rhel_dependencies }}"
+        update_cache: true
+        state: latest  # noqa package-latest
 
     - name: (RHEL) Set up RHEL repository
       yum_repository:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -33,23 +33,21 @@ nginx_app_protect_dos_linux_families:
   ]
 
 # Alpine Linux dependencies
-nginx_app_protect_alpine_dependencies: [
-  "python3",
-]
+nginx_app_protect_alpine_dependencies: []
 
 # Debian dependencies
 nginx_app_protect_debian_dependencies: [
-  "apt-transport-https", "ca-certificates", "dirmngr",
+  "apt-transport-https", "ca-certificates",
 ]
 
 # CentOS dependencies
 nginx_app_protect_centos_dependencies: [
-  "ca-certificates", "epel-release", "openssl",
+  "ca-certificates", "epel-release",
 ]
 
 # RHEL dependencies
 nginx_app_protect_rhel_dependencies: [
-  "ca-certificates", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm", "openssl",
+  "ca-certificates", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
 ]
 
 # Amazon Linux 2 dependencies


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

Move non NGINX App Protect specific dependencies from the role into the Molecule Dockerfile.

BUG FIXES:

Always update NGINX App Protect dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
