### PR TITLE
Support NAP WAF 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,21 @@
 
 ENHANCEMENTS:
 
+* Remove Alpine 3.10 from the list of supported platform for NAP (and from Molecule).
 * Move non NGINX App Protect specific dependencies from the role into the Molecule Dockerfile.
 * Change Dependabot frequency from daily to weekly.
 * Minor touch-up of GitHub actions workflows.
 
 BUG FIXES:
 
-Always update NGINX App Protect dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+* NGINX App Protect WAF 3.6 has been released and with it comes support for NGINX Plus R25. Per last release's KNOWN ISSUES, NGINX App Protect DoS will still only work with NGINX Plus R24.
+* Always update NGINX App Protect dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
 
 ## 0.6.1 (September 30, 2021)
 
 KNOWN ISSUES:
 
-As of the latest NGINX Plus release, R25, NGINX App Protect will no longer install or work on R25 platforms. The only workaround at this time is to install NGINX Plus R24 before attempting to install NGINX App Protect WAF/DoS. This issue will be fixed in NGINX App Protect 3.6, planned for release mid-October.
+As of the latest NGINX Plus release, R25, NGINX App Protect WAF/DoS will no longer install or work on R25 platforms. The only workaround at this time is to install NGINX Plus R24 before attempting to install NGINX App Protect WAF/DoS. This issue will be fixed in NGINX App Protect WAF 3.6, planned for release mid-October, and in the next release of NGINX App Protect DoS, also planned for release mid-October.
 
 ENHANCEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,11 @@ Use `git clone https://github.com/nginxinc/ansible-role-nginx-app-protect.git` t
 The NGINX App Protect Ansible role supports all platforms supported by [NGINX Plus](https://www.nginx.com/products/technical-specs/) that intersect with the following list of distributions of App Protect WAF:
 
 ```yaml
-Alpine:
-  - 3.10
 Amazon Linux 2:
   - any
 CentOS:
   - 7.4+
 Debian:
-  - stretch (9)
   - buster (10)
 RHEL:
   - 7.4+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,9 +11,6 @@ galaxy_info:
   min_ansible_version: 2.11
 
   platforms:
-    - name: Alpine
-      versions:
-        - any
     - name: Amazon Linux 2
       versions:
         - any

--- a/molecule/advanced/converge.yml
+++ b/molecule/advanced/converge.yml
@@ -13,12 +13,4 @@
         nginx_app_protect_install_signatures: true
         nginx_app_protect_install_threat_campaigns: true
         nginx_app_protect_configure: true
-        nginx_app_protect_security_policy_template_enable: true
-        nginx_app_protect_security_policy_enforcement_mode: blocking
-        nginx_app_protect_log_policy_template_enable: true
-        nginx_app_protect_log_policy_filter_request_type: all
-        nginx_app_protect_conf_template_enable: true
-        nginx_app_protect_demo_workload_protocol: http://
-        nginx_app_protect_demo_workload_host: test-workload:80
-        nginx_app_protect_log_policy_syslog_target: localhost:514
         nginx_app_protect_timeout: 180

--- a/molecule/advanced/molecule.yml
+++ b/molecule/advanced/molecule.yml
@@ -17,17 +17,6 @@ platforms:
       - workload
     networks:
       - name: molecule-test
-  - name: alpine-3.10
-    image: alpine:3.10
-    dockerfile: ../Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
-    groups:
-      - nap
-    networks:
-      - name: molecule-test
   - name: centos-7
     image: centos:7
     dockerfile: ../Dockerfile.j2

--- a/molecule/advanced/prepare.yml
+++ b/molecule/advanced/prepare.yml
@@ -35,28 +35,3 @@
     - name: Start nginx on test workload
       raw: nohup nginx </dev/null >/dev/null 2>&1 & sleep 1
       changed_when: false
-
-- name: Install NGINX Plus R24 to avoid dependency issues
-  hosts: nap
-  tasks:
-    - name: Set repo if Alpine
-      set_fact:
-        version: "=24-r2"
-      when: ansible_facts['os_family'] == "Alpine"
-    - name: Set repo if Debian
-      set_fact:
-        version: "=24-2~{{ ansible_facts['distribution_release'] }}"
-      when: ansible_facts['os_family'] == "Debian"
-    - name: Set repo if Red Hat
-      set_fact:
-        version: "-24-2.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
-      when: ansible_facts['os_family'] == "RedHat"
-    - name: Install NGINX Plus R24 to avoid dependency issues
-      include_role:
-        name: nginxinc.nginx
-      vars:
-        nginx_type: plus
-        nginx_version: "{{ version }}"
-        nginx_license:
-          certificate: ../../files/license/nginx-repo.crt
-          key: ../../files/license/nginx-repo.key

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,8 +1,4 @@
 ---
-dependency:
-  name: galaxy
-  options:
-    role-file: molecule/default/requirements.yml
 driver:
   name: docker
 lint: |
@@ -10,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.10
-    image: alpine:3.10
-    dockerfile: ../Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../Dockerfile.j2
@@ -55,6 +44,5 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    prepare: prepare.yml
     converge: converge.yml
     verify: verify.yml

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -16,28 +16,3 @@
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444
-
-- name: Install NGINX Plus R24 to avoid dependency issues
-  hosts: all
-  tasks:
-    - name: Set repo if Alpine
-      set_fact:
-        version: "=24-r2"
-      when: ansible_facts['os_family'] == "Alpine"
-    - name: Set repo if Debian
-      set_fact:
-        version: "=24-2~{{ ansible_facts['distribution_release'] }}"
-      when: ansible_facts['os_family'] == "Debian"
-    - name: Set repo if Red Hat
-      set_fact:
-        version: "-24-2.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
-      when: ansible_facts['os_family'] == "RedHat"
-    - name: Install NGINX Plus R24 to avoid dependency issues
-      include_role:
-        name: nginxinc.nginx
-      vars:
-        nginx_type: plus
-        nginx_version: "{{ version }}"
-        nginx_license:
-          certificate: ../../files/license/nginx-repo.crt
-          key: ../../files/license/nginx-repo.key

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,0 @@
----
-roles:
-  - name: nginxinc.nginx
-    version: 0.21.2

--- a/molecule/dos/prepare.yml
+++ b/molecule/dos/prepare.yml
@@ -16,21 +16,18 @@
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444
+
 - name: Install NGINX Plus R24 to avoid dependency issues
   hosts: all
   tasks:
-    - name: Set repo if Alpine
-      set_fact:
-        version: "=24-r2"
-      when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       set_fact:
-        version: "=24-2~{{ ansible_facts['distribution_release'] }}"
-      when: ansible_facts['os_family'] == "Debian"
+        version: "=24-2~{{ ansible_distribution_release }}"
+      when: ansible_os_family == "Debian"
     - name: Set repo if Red Hat
       set_fact:
-        version: "-24-2.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
-      when: ansible_facts['os_family'] == "RedHat"
+        version: "-24-2.{{ (ansible_distribution =='Amazon') | ternary('amzn2', ('el' + ansible_distribution_major_version | string)) }}.ngx"
+      when: ansible_os_family == "RedHat"
     - name: Install NGINX Plus R24 to avoid dependency issues
       include_role:
         name: nginxinc.nginx

--- a/molecule/specific-version/molecule.yml
+++ b/molecule/specific-version/molecule.yml
@@ -10,13 +10,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.10
-    image: alpine:3.10
-    dockerfile: ../Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: centos-7
     image: centos:7
     dockerfile: ../Dockerfile.j2


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

Remove Alpine 3.10 from the list of supported platform for NAP (and from Molecule).

BUG FIXES:

NGINX App Protect WAF 3.6 has been released and with it comes support for NGINX Plus R25. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
