### PR TITLE
Still setup key/license when neither signatures/threats are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.1 (Unreleased)
+
+ENHANCEMENTS:
+
+Add signing keys to a unique NGINX keyring on Debian based systems.
+
+BUG FIXES:
+
+License and keys should now be correctly setup when neither signatures or threat campaigns are installed.
+
 ## 0.7.0 (October 28, 2021)
 
 BREAKING CHANGES:

--- a/tasks/common/keys/setup-keys.yml
+++ b/tasks/common/keys/setup-keys.yml
@@ -18,10 +18,12 @@
   block:
     - name: (Debian/Ubuntu) Add NGINX Plus signing key
       apt_key:
+        keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
         url: "{{ nginx_app_protect_signing_key.nginx_plus | default(nginx_app_protect_default_signing_key_pgp) }}"
 
     - name: (Debian/Ubuntu) Add NGINX App Protect security updates signing key
       apt_key:
+        keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
         url: "{{ nginx_app_protect_signing_key.security_updates | default(nginx_app_protect_security_updates_default_signing_key_pgp) }}"
   when: ansible_os_family == "Debian"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,16 +34,11 @@
 
     - name: Set up signing keys
       include_tasks: "{{ role_path }}/tasks/common/keys/setup-keys.yml"
-      when: nginx_app_protect_install_signatures | bool
-            or nginx_app_protect_install_threat_campaigns | bool
       tags: nginx_app_protect_key
 
     - name: Set up license
       include_tasks: "{{ role_path }}/tasks/common/install/setup-license.yml"
-      when:
-        - nginx_app_protect_install_signatures | bool
-          or nginx_app_protect_install_threat_campaigns | bool
-        - nginx_app_protect_setup_license | bool
+      when: nginx_app_protect_setup_license | bool
       tags: nginx_app_protect_setup_license
 
     - name: Install NGINX App Protect WAF

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -61,22 +61,22 @@ nginx_app_protect_security_updates_default_signing_key_rsa_pub: https://cs.nginx
 
 # Default NGINX Plus repositories
 nginx_plus_default_repository_alpine: "https://pkgs.nginx.com/plus/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
-nginx_plus_default_repository_debian: "deb [arch=amd64] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
+nginx_plus_default_repository_debian: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg arch=amd64] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
 nginx_plus_default_repository_redhat: "https://pkgs.nginx.com/plus/centos/{{ ansible_distribution_major_version }}/$basearch/"
 nginx_plus_default_repository_amazon: "https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch"
 
 # Default NGINX App Protect WAF repositories
 nginx_app_protect_default_repository_alpine: "https://pkgs.nginx.com/app-protect/alpine/v{{ ansible_distribution_version | regex_search('^[0-9]+\\.[0-9]+') }}/main"
-nginx_app_protect_default_repository_debian: "deb [arch=amd64] https://pkgs.nginx.com/app-protect/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
+nginx_app_protect_default_repository_debian: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg arch=amd64] https://pkgs.nginx.com/app-protect/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
 nginx_app_protect_default_repository_redhat: "https://pkgs.nginx.com/app-protect/centos/{{ ansible_distribution_major_version }}/$basearch/"
 nginx_app_protect_default_repository_amazon: "https://pkgs.nginx.com/app-protect/centos/7/$basearch/"
 
 # Default NGINX App Protect WAF Security Updates repositories
 nginx_app_protect_security_updates_default_repository_alpine: "https://pkgs.nginx.com/app-protect-security-updates/alpine/v{{ ansible_distribution_version | regex_search('^[0-9]+\\.[0-9]+') }}/main"
-nginx_app_protect_security_updates_default_repository_debian: "deb [arch=amd64] https://pkgs.nginx.com/app-protect-security-updates/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
+nginx_app_protect_security_updates_default_repository_debian: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg arch=amd64] https://pkgs.nginx.com/app-protect-security-updates/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
 nginx_app_protect_security_updates_default_repository_redhat: "https://pkgs.nginx.com/app-protect-security-updates/centos/{{ ansible_distribution_major_version }}/$basearch/"
 nginx_app_protect_security_updates_default_repository_amazon: "https://pkgs.nginx.com/app-protect-security-updates/centos/7/$basearch/"
 
 # Default NGINX App Protect DoS repositories
-nginx_app_protect_dos_default_repository_debian: "deb [arch=amd64] https://pkgs.nginx.com/app-protect-dos/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
+nginx_app_protect_dos_default_repository_debian: "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg arch=amd64] https://pkgs.nginx.com/app-protect-dos/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus"
 nginx_app_protect_dos_default_repository_redhat: "https://pkgs.nginx.com/app-protect-dos/centos/{{ ansible_distribution_major_version }}/$basearch/"


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

Add signing keys to a unique NGINX keyring on Debian based systems.

BUG FIXES:

License and keys should now be correctly setup when neither signatures or threat campaigns are installed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
