### PR TITLE
Ansible check mode fails if NGINX is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 
 * Role was failing to uninstall NGINX App Protect DoS packages when the `nginx_app_protect_dos_state` was set to `absent`.
 * Uninstallation scenario was unintentionally creating repository entries.
+* Ansible check mode runs will no longer fail if NGINX has not yet been installed.
 
 ## 0.7.1 (February 16, 2022)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,16 +15,17 @@
 
 - name: (Handler - NGINX App Protect) Check NGINX
   command: nginx -t
-  register: config
+  register: config_check
   ignore_errors: true
   changed_when: false
   listen: (Handler - NGINX App Protect) Run NGINX
 
 - name: (Handler - NGINX App Protect) Print NGINX error if syntax check fails
   debug:
-    var: config.stderr_lines
-  failed_when: config.rc != 0
+    var: config_check.stderr_lines
+  failed_when: config_check.rc != 0
   when:
-    - config.rc is defined
-    - config.rc != 0
+    - config_check.stderr_lines is defined
+    - config_check.stderr_lines != []
+    - config_check.rc != 0
   listen: (Handler - NGINX App Protect) Run NGINX


### PR DESCRIPTION
### Proposed changes

Ansible check mode runs will no longer fail if NGINX has not yet been installed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
