### PR TITLE
Rename modules to use Ansible FQCNs

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 4.4.0
+    version: 4.6.1
   - name: ansible.posix
     version: 1.3.0
   - name: community.docker
-    version: 2.1.1
+    version: 2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ENHANCEMENTS:
 * Add support of RHEL 8.1+ for NGINX App Protect WAF 3.8.
 * Add support of RHEL 7.4+ and 8.x for NGINX App Protect DoS 2.1.
 * New molecule tests for RHEL 7/8 and for NGINX App Protect WAF/DoS removal scenarios.
+* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ BREAKING CHANGES:
 * Cleanup deprecated Alpine Linux tasks.
 * Remove `nginx_app_protect_configure` parameter since it has limited functionality given the `nginx_app_protect_*_policy_file_enable` parameters.
 
+FEATURES:
+
+Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
+
 ENHANCEMENTS:
 
 * Add support of RHEL 8.1+ for NGINX App Protect WAF 3.8.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,3 +35,7 @@ galaxy_info:
     - server
     - development
     - dos
+
+collections:
+  - ansible.posix
+  - community.general

--- a/molecule/common/cleanup.yml
+++ b/molecule/common/cleanup.yml
@@ -24,7 +24,7 @@
               - distribution
 
         - name: (RHEL) Unregister system from RHEL subscription manager
-          redhat_subscription:
+          community.general.redhat_subscription:
             state: absent
           when: ansible_distribution == "RedHat"
       rescue:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,7 +12,7 @@
         - lookup('env', 'RHEL_PASSWORD') | length > 0
 
     - name: (RHEL) Register system into RHEL subscription manager
-      redhat_subscription:
+      community.general.redhat_subscription:
         username: "{{ lookup('env', 'RHEL_USERNAME') }}"
         password: "{{ lookup('env', 'RHEL_PASSWORD') }}"
       when:

--- a/molecule/dos/converge.yml
+++ b/molecule/dos/converge.yml
@@ -12,7 +12,7 @@
         - lookup('env', 'RHEL_PASSWORD') | length > 0
 
     - name: (RHEL) Register system into RHEL subscription manager
-      redhat_subscription:
+      community.general.redhat_subscription:
         username: "{{ lookup('env', 'RHEL_USERNAME') }}"
         password: "{{ lookup('env', 'RHEL_PASSWORD') }}"
       when:

--- a/molecule/uninstall/prepare.yml
+++ b/molecule/uninstall/prepare.yml
@@ -30,7 +30,7 @@
         - lookup('env', 'RHEL_PASSWORD') | length > 0
 
     - name: (RHEL) Register system into RHEL subscription manager
-      redhat_subscription:
+      community.general.redhat_subscription:
         username: "{{ lookup('env', 'RHEL_USERNAME') }}"
         password: "{{ lookup('env', 'RHEL_PASSWORD') }}"
       when:
@@ -51,7 +51,7 @@
         nginx_app_protect_dos_enable: true
   post_tasks:
     - name: (RHEL) Unregister system from RHEL subscription manager
-      redhat_subscription:
+      community.general.redhat_subscription:
         state: absent
       when:
         - ansible_distribution == "RedHat"

--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -56,7 +56,7 @@
         - nginx_app_protect_dos_enable | bool
 
     - name: (RHEL 7) Set up RHEL dependencies from RHEL official repositories
-      rhsm_repository:
+      community.general.rhsm_repository:
         name:
           - rhel-7-server-optional-rpms
           - rhel-7-server-extras-rpms
@@ -66,7 +66,7 @@
         - nginx_app_protect_use_rhel_subscription_repos | bool
 
     - name: (RHEL 8) Set up RHEL dependencies from RHEL official repositories
-      rhsm_repository:
+      community.general.rhsm_repository:
         name: codeready-builder-for-rhel-8-x86_64-rpms
       when:
         - ansible_distribution_major_version == "8"


### PR DESCRIPTION
### Proposed changes

* Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation (`defaults/main.yml`, `README.md` and `CHANGELOG.md`)
