### PR TITLE
Add `TimeoutStartSec` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ BREAKING CHANGES:
 * Rename multiple `nginx_app_protect_*` parameters and tags to `nginx_app_protect_waf_*` to aid in disambiguation.
 * Cleanup deprecated Alpine Linux tasks.
 * Remove `nginx_app_protect_configure` parameter since it has limited functionality given the `nginx_app_protect_*_policy_file_enable` parameters.
+* The `nginx_app_protect_timeout` setting previous only applied to service stop operations. This parameter has been changed to `nginx_app_protect_timeoutstopsec` to better reflect its usage, and a new parameter, `nginx_app_protect_timeoutstartsec` has been introduced to tweak service start operation timeouts.
 
 FEATURES:
 
@@ -26,7 +27,6 @@ BUG FIXES:
 * Role was failing to uninstall NGINX App Protect DoS packages when the `nginx_app_protect_dos_state` was set to `absent`.
 * Uninstallation scenario was unintentionally creating repository entries.
 * Ansible check mode runs will no longer fail if NGINX has not yet been installed.
-* The `nginx_app_protect_timeout` setting previous only applied to service stop operations. Now includes both start and stop operations.
 
 ## 0.7.1 (February 16, 2022)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -97,7 +97,8 @@ nginx_app_protect_start: true
 # Increase NGINX service timeout to accommodate ruleset loading from default 90s.
 # Default is commented out.
 nginx_app_protect_service_modify: true
-nginx_app_protect_timeout: 180
+nginx_app_protect_timeoutstartsec: 180
+nginx_app_protect_timeoutstopcsec: 180
 
 # Copy local NGINX App Protect security policy to host
 nginx_app_protect_security_policy_file_enable: false

--- a/molecule/advanced/converge.yml
+++ b/molecule/advanced/converge.yml
@@ -12,4 +12,4 @@
         nginx_app_protect_remove_license: false
         nginx_app_protect_waf_install_signatures: true
         nginx_app_protect_waf_install_threat_campaigns: true
-        nginx_app_protect_timeout: 180
+        nginx_app_protect_timeoutstartsec: 180

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -1,3 +1,7 @@
 [Service]
-# Override default 90 second timeout
-TimeoutSec={{ nginx_app_protect_timeout }}
+{% if nginx_app_protect_timeoutstartsec is defined %}
+TimeoutStartSec={{ nginx_app_protect_timeoutstartsec }}
+{% endif %}
+{% if nginx_app_protect_timeoutstopsec is defined %}
+TimeoutStopSec={{ nginx_app_protect_timeoutstopsec }}
+{% endif %}


### PR DESCRIPTION
### Proposed changes

The `nginx_app_protect_timeout` setting previous only applied to service stop operations. This parameter has been changed to `nginx_app_protect_timeoutstopsec` to better reflect its usage, and a new parameter, `nginx_app_protect_timeoutstartsec` has been introduced to tweak service start operation timeouts.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
