### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 4.7.0
+    version: 5.1.0
   - name: ansible.posix
-    version: 1.3.0
+    version: 1.4.0
   - name: community.docker
-    version: 2.3.0
+    version: 2.6.0

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: community.general
-    version: 5.1.0
+    version: 5.1.1
   - name: ansible.posix
     version: 1.4.0
   - name: community.docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ENHANCEMENTS:
 
-Bump the Ansible `community.general` collection to `5.1.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.1 (Unreleased)
 
+ENHANCEMENTS:
+
+Bump the Ansible `community.general` collection to `5.1.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+
 BUG FIXES:
 
 Always refresh the `yum` cache.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you wish to install NGINX App Protect WAF or NGINX App Protect DoS using this
     ---
     collections:
       - name: community.general
-        version: 5.1.0
+        version: 5.1.1
       - name: ansible.posix
         version: 1.4.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ If you wish to install NGINX App Protect WAF or NGINX App Protect DoS using this
     ---
     collections:
       - name: community.general
-        version: 4.7.0
+        version: 5.1.0
       - name: ansible.posix
-        version: 1.3.0
+        version: 1.4.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 2.3.0
+        version: 2.6.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `5.1.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
