### PR TITLE
Skip GH action *plus* tests only when secrets aren't present

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,25 +27,21 @@ jobs:
           - uninstall
     steps:
       - name: Check out the codebase
-        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@v3
 
       - name: Set up Python 3
-        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
       - name: Install Molecule dependencies
-        if: github.event.pull_request.head.repo.full_name == github.repository
         run: pip3 install -r .github/workflows/requirements/requirements_molecule.txt
 
-      - name: Install Ansible base dependencies
-        if: github.event.pull_request.head.repo.full_name == github.repository
+      - name: Install Ansible core dependencies
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
       - name: Run Molecule tests
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ env.NGINX_CRT != 0 && env.NGINX_KEY != 0 }}
         run: molecule test -s ${{ matrix.scenario }}
         env:
           PY_COLORS: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Always refresh the `yum` cache.
 
 TESTS:
 
+* Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).
 * Remove Yamllint (Ansible Lint now incorporates Yamllint).
 * Skip Ansible Lint line length rule.
 


### PR DESCRIPTION
### Proposed changes

Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
