### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 5.1.1
+    version: 5.5.0
   - name: ansible.posix
     version: 1.4.0
   - name: community.docker
-    version: 2.6.0
+    version: 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ENHANCEMENTS:
 
-Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
+Bump the Ansible `community.general` collection to `5.501`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `3.1.0`.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ If you wish to install NGINX App Protect WAF or NGINX App Protect DoS using this
     ---
     collections:
       - name: community.general
-        version: 5.1.1
+        version: 5.5.0
       - name: ansible.posix
         version: 1.4.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 2.6.0
+        version: 3.1.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.

--- a/molecule/advanced/prepare.yml
+++ b/molecule/advanced/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/molecule/specific-version/converge.yml
+++ b/molecule/specific-version/converge.yml
@@ -14,12 +14,12 @@
     - name: Set NGINX App Protect WAF signature version fact
       ansible.builtin.set_fact:
         nginx_app_protect_waf_signatures_version: "{{ app_protect_signature_version_matrix[ansible_os_family | lower] }}{{ (ansible_os_family | lower == 'debian') | ternary('~' ~ ansible_distribution_release, '') }}"
-      when: specify_app_protect_signatures_version| bool
+      when: specify_app_protect_signatures_version | bool
 
     - name: Set NGINX App Protect WAF threat campaigns version fact
       ansible.builtin.set_fact:
         nginx_app_protect_waf_threat_campaigns_version: "{{ app_protect_threat_campaigns_version_matrix[ansible_os_family | lower] }}{{ (ansible_os_family | lower == 'debian') | ternary('~' ~ ansible_distribution_release, '') }}"
-      when: specify_app_protect_threat_campaigns_version| bool
+      when: specify_app_protect_threat_campaigns_version | bool
 
     - name: Install NGINX App Protect WAF
       ansible.builtin.include_role:

--- a/molecule/specific-version/verify.yml
+++ b/molecule/specific-version/verify.yml
@@ -58,10 +58,10 @@
           ansible.builtin.package_facts:
             manager: auto
 
-        - name: Verify installed NAP signatures version matches requested version # noqa var-spacing
+        - name: Verify installed NAP signatures version matches requested version # noqa jinja[spacing]
           ansible.builtin.assert:
             that: "{{ (ansible_facts.packages['app-protect-attack-signatures'] | map(attribute='version') | first) == (app_protect_signature_version_matrix[ansible_os_family | lower] | regex_replace('^-|=','') + (ansible_os_family | lower == 'debian') | ternary('~' ~ ansible_distribution_release, '')) }}"
 
-        - name: Verify installed NAP threat campaigns version matches requested version # noqa var-spacing
+        - name: Verify installed NAP threat campaigns version matches requested version # noqa jinja[spacing]
           ansible.builtin.assert:
             that: "{{ (ansible_facts.packages['app-protect-threat-campaigns'] | map(attribute='version') | first) == (app_protect_threat_campaigns_version_matrix[ansible_os_family | lower] | regex_replace('^-|=','') + (ansible_os_family | lower == 'debian') | ternary('~' ~ ansible_distribution_release, '')) }}"

--- a/molecule/uninstall/prepare.yml
+++ b/molecule/uninstall/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/tasks/common/config/configure-app-protect.yml
+++ b/tasks/common/config/configure-app-protect.yml
@@ -33,4 +33,4 @@
         backup: true
         mode: 0644
       loop: "{{ nginx_app_protect_log_policy_file }}"
-  when: nginx_app_protect_log_policy_file_enable  | bool
+  when: nginx_app_protect_log_policy_file_enable | bool

--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -36,7 +36,7 @@
         enabled: true
         gpgcheck: true
         gpgkey: https://ftp.heanet.ie/pub/centos/7/os/$basearch/RPM-GPG-KEY-CentOS-7
-        state: "{{ nginx_app_protect_license_status | default ('present') }}"
+        state: "{{ nginx_app_protect_license_status | default('present') }}"
       when:
         - ansible_distribution_major_version == "7"
         - not nginx_app_protect_use_rhel_subscription_repos | bool
@@ -49,7 +49,7 @@
         enabled: true
         gpgcheck: true
         gpgkey: http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
-        state: "{{ nginx_app_protect_license_status | default ('present') }}"
+        state: "{{ nginx_app_protect_license_status | default('present') }}"
       when:
         - ansible_distribution_major_version == "7"
         - not nginx_app_protect_use_rhel_subscription_repos | bool


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `5.5.0` and `community.docker` collection to `3.1.0`, and address Linter warnings.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
