### PR TITLE
Add support for new NAP DoS distros

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -8,4 +8,3 @@ collections:
     version: 3.1.0
   - name: community.general
     version: 5.5.0
-

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,11 @@
 ---
 collections:
-  - name: community.general
-    version: 5.5.0
   - name: ansible.posix
     version: 1.4.0
+  - name: community.crypto
+    version: 2.5.0
   - name: community.docker
     version: 3.1.0
+  - name: community.general
+    version: 5.5.0
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.8.1 (Unreleased)
 
+FEATURES:
+
+* Add support for Alpine Linux for NGINX App Protect DoS.
+* Add support for Debian bullseye for NGINX App Protect DoS.
+
 ENHANCEMENTS:
 
 Bump the Ansible `community.general` collection to `5.501`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `3.1.0`.
@@ -33,8 +38,8 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* Add support of RHEL 8.1+ for NGINX App Protect WAF 3.8.
-* Add support of RHEL 7.4+ and 8.x for NGINX App Protect DoS 2.1.
+* Add support for RHEL 8.1+ for NGINX App Protect WAF 3.8.
+* Add support for RHEL 7.4+ and 8.x for NGINX App Protect DoS 2.1.
 * New molecule tests for RHEL 7/8 and for NGINX App Protect WAF/DoS removal scenarios.
 * Bump the Ansible `community.general` collection to `4.7.0` and `community.docker` collection to `2.3.0`.
 * Update Dependabot to trigger updates at the same time across all NGINX core roles at the same time and to avoid triggering release drafter on GitHub actions dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 * Add support for Alpine Linux for NGINX App Protect DoS.
 * Add support for Debian bullseye for NGINX App Protect DoS.
+* Check NGINX App Protect license is valid before trying to install NGINX App Protect (this means the role now requires the `community.crypto` collection).
 
 ENHANCEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ If you wish to install NGINX App Protect WAF or NGINX App Protect DoS using this
     ```yaml
     ---
     collections:
-      - name: community.general
-        version: 5.5.0
       - name: ansible.posix
         version: 1.4.0
+      - name: community.crypto
+        version: 2.5.0
+      - name: community.general
+        version: 5.5.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
         version: 3.1.0
     ```

--- a/molecule/dos/molecule.yml
+++ b/molecule/dos/molecule.yml
@@ -5,6 +5,13 @@ lint: |
   set -e
   ansible-lint --force-color
 platforms:
+  - name: alpine-3.15
+    image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
@@ -28,6 +35,13 @@ platforms:
     command: /usr/sbin/init
   - name: debian-buster
     image: debian:buster-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bullseye
+    image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/tasks/common/install/setup-license.yml
+++ b/tasks/common/install/setup-license.yml
@@ -1,16 +1,86 @@
 ---
-- name: (Debian/Red Hat OSs) Create SSL directory
-  ansible.builtin.file:
-    path: /etc/ssl/nginx
-    state: directory
-    mode: 0755
+- name: (Alpine Linux) Set up NGINX App Protect WAF/DoS license
+  block:
+    - name: Install cryptography package
+      ansible.builtin.package:
+        name: py3-cryptography
 
-- name: (Debian/Red Hat OSs) Copy NGINX App Protect certificate and license key
-  ansible.builtin.copy:
-    src: "{{ item }}"
-    dest: /etc/ssl/nginx
-    decrypt: true
-    mode: 0444
-  loop:
-    - "{{ nginx_app_protect_license.certificate }}"
-    - "{{ nginx_app_protect_license.key }}"
+    - name: (Alpine Linux) Create APK directory
+      ansible.builtin.file:
+        path: /etc/apk
+        state: directory
+        mode: 0755
+
+    - name: (Alpine Linux) Copy NGINX App Protect WAF/DoS certificate
+      ansible.builtin.copy:
+        src: "{{ nginx_app_protect_license.certificate }}"
+        dest: /etc/apk/cert.pem
+        decrypt: true
+        mode: 0444
+
+    - name: (Alpine Linux) Copy NGINX App Protect WAF/DoS key
+      ansible.builtin.copy:
+        src: "{{ nginx_app_protect_license.key }}"
+        dest: /etc/apk/cert.key
+        decrypt: true
+        mode: 0444
+
+    - name: (Alpine Linux) Check that NGINX App Protect WAF/DoS certificate is valid
+      community.crypto.x509_certificate_info:
+        path: /etc/apk/cert.pem
+      register: cert
+
+    - name: (Alpine Linux) Check that NGINX App Protect WAF/DoS key is valid
+      community.crypto.openssl_privatekey_info:
+        path: /etc/apk/cert.key
+      register: key
+
+    - name: (Alpine Linux) Check that NGINX App Protect WAF/DoS license is valid
+      ansible.builtin.assert:
+        that:
+          - cert.expired == false
+          - cert.public_key == key.public_key
+        success_msg: Your NGINX App Protect WAF/DoS license is valid!
+        fail_msg: Something went wrong! Make sure your App Protect WAF/DoS license is valid!
+  when: ansible_os_family == "Alpine"
+
+- name: (Debian/Red Hat OSs) Set up NGINX App Protect WAF/DoS license
+  block:
+    - name: (Debian/Red Hat OSs) Create SSL directory
+      ansible.builtin.file:
+        path: /etc/ssl/nginx
+        state: directory
+        mode: 0755
+
+    - name: (Debian/Red Hat OSs) Copy NGINX App Protect WAF/DoS certificate and license key
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: /etc/ssl/nginx
+        decrypt: true
+        mode: 0444
+      loop:
+        - "{{ nginx_app_protect_license.certificate }}"
+        - "{{ nginx_app_protect_license.key }}"
+
+    - name: (Debian/Red Hat OSs) Install cryptography package
+      ansible.builtin.package:
+        name: "{{ (ansible_python_version_major == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
+
+    - name: (Debian/Red Hat OSs) Check that NGINX App Protect WAF/DoS certificate is valid
+      community.crypto.x509_certificate_info:
+        path: /etc/ssl/nginx/nginx-repo.crt
+      register: cert
+
+    - name: (Debian/Red Hat OSs) Check that NGINX App Protect WAF/DoS key is valid
+      community.crypto.openssl_privatekey_info:
+        path: /etc/ssl/nginx/nginx-repo.key
+      register: key
+
+    - name: (Debian/Red Hat OSs) Check that NGINX App Protect WAF/DoS license is valid
+      ansible.builtin.assert:
+        that:
+          - cert.expired == false
+          - cert.public_key == key.public_key
+        success_msg: Your NGINX App Protect WAF/DoS license is valid!
+        fail_msg: Something went wrong! Make sure your NGINX App Protect WAF/DoS license is valid!
+  when: ansible_os_family != "Alpine"

--- a/tasks/common/install/setup-license.yml
+++ b/tasks/common/install/setup-license.yml
@@ -64,7 +64,7 @@
 
     - name: (Debian/Red Hat OSs) Install cryptography package
       ansible.builtin.package:
-        name: "{{ (ansible_python_version_major == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
+        name: "{{ (ansible_python.version.major == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
 
     - name: (Debian/Red Hat OSs) Check that NGINX App Protect WAF/DoS certificate is valid
       community.crypto.x509_certificate_info:

--- a/tasks/common/keys/setup-keys.yml
+++ b/tasks/common/keys/setup-keys.yml
@@ -1,4 +1,17 @@
 ---
+- name: (Alpine Linux) Set up NGINX App Protect DoS signing key
+  block:
+    - name: (Alpine Linux) Set up NGINX App Protect DoS signing key URL
+      ansible.builtin.set_fact:
+        keysite: "{{ nginx_app_protect_signing_key.nginx_plus | default(nginx_app_protect_default_signing_key_rsa_pub) }}"
+
+    - name: (Alpine Linux) Download NGINX App Protect DoS signing key
+      ansible.builtin.get_url:
+        url: "{{ keysite }}"
+        dest: /etc/apk/keys/nginx_signing.rsa.pub
+        mode: 0400
+  when: ansible_os_family == "Alpine"
+
 - name: (Debian/Ubuntu) Set up NGINX App Protect and security updates signing key
   block:
     - name: (Debian/Ubuntu) Add NGINX Plus signing key

--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -1,4 +1,11 @@
 ---
+- name: (Alpine Linux) Install package dependencies
+  community.general.apk:
+    name: "{{ nginx_app_protect_alpine_dependencies }}"
+    update_cache: true
+    state: latest # noqa package-latest
+  when: ansible_os_family == "Alpine"
+
 - name: (Debian/Ubuntu) Install package dependencies
   ansible.builtin.apt:
     name: "{{ nginx_app_protect_debian_dependencies }}"

--- a/tasks/dos/install-alpine.yml
+++ b/tasks/dos/install-alpine.yml
@@ -1,0 +1,34 @@
+---
+- name: (Alpine Linux) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
+  ansible.builtin.lineinfile:
+    path: /etc/apk/repositories
+    insertafter: EOF
+    line: "{{ nginx_plus_repository | default(nginx_plus_default_repository_alpine) }}"
+    state: "{{ nginx_app_protect_license_status | default((nginx_app_protect_dos_setup == 'uninstall') | ternary('absent', 'present')) }}"
+  when: nginx_app_protect_dos_manage_repo | bool
+
+- name: (Alpine Linux) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect DoS repository
+  ansible.builtin.lineinfile:
+    path: /etc/apk/repositories
+    insertafter: EOF
+    line: "{{ nginx_app_protect_dos_repository | default(nginx_app_protect_dos_default_repository_alpine) }}"
+    state: "{{ nginx_app_protect_license_status | default((nginx_app_protect_dos_setup == 'uninstall') | ternary('absent', 'present')) }}"
+  when: nginx_app_protect_dos_manage_repo | bool
+
+- name: (Alpine Linux) {{ nginx_app_protect_dos_setup | capitalize }} NGINX Plus
+  community.general.apk:
+    name: nginx-plus
+    repository: "{{ nginx_plus_repository | default(nginx_plus_default_repository_alpine) }}"
+    state: "{{ nginx_app_protect_dos_state }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: nginx_app_protect_license_status is not defined
+  notify: (Handler - NGINX App Protect) Run NGINX
+
+- name: (Alpine Linux) {{ nginx_app_protect_dos_setup | capitalize }} NGINX App Protect DoS
+  community.general.apk:
+    name: app-protect-dos{{ (nginx_app_protect_dos_state == 'absent') | ternary(',nginx-plus-module-appprotectdos', '') }}
+    repository: "{{ nginx_app_protect_dos_repository | default(nginx_app_protect_dos_default_repository_alpine) }}"
+    state: "{{ nginx_app_protect_dos_state }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  when: nginx_app_protect_license_status is not defined
+  notify: (Handler - NGINX App Protect) Run NGINX

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,11 +19,14 @@ nginx_app_protect_waf_linux_families:
 
 # NGINX App Protect DoS platform matrix. Populate this dictionary of lists with appropriate values from ansible_distribution and ansible_distribution_version facts
 nginx_app_protect_dos_linux_families:
+  alpine: [
+    "3.15",
+  ]
   centos: [
     "7.4", "7.5", "7.6", "7.7", "7.8", "7.9",
   ]
   debian: [
-    "10",
+    "10", "11",
   ]
   redhat: [
     "7.4", "7.5", "7.6", "7.7", "7.8", "7.9", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5",
@@ -46,6 +49,11 @@ nginx_app_protect_waf_state: "{{ nginx_app_protect_state_vals[nginx_app_protect_
 
 nginx_app_protect_dos_default_setup: install
 nginx_app_protect_dos_state: "{{ nginx_app_protect_state_vals[nginx_app_protect_dos_setup] | default(nginx_app_protect_state_vals[nginx_app_protect_dos_default_setup]) }}"
+
+# Alpine Linux dependencies
+nginx_app_protect_alpine_dependencies: [
+  boost, ca-certificates, coreutils, openssl, pcre2, zeromq,
+]
 
 # Amazon Linux 2 extras
 nginx_app_protect_amazon_extras: [
@@ -71,20 +79,22 @@ nginx_app_protect_waf_security_updates_default_signing_key_pgp: https://cs.nginx
 nginx_app_protect_waf_security_updates_default_signing_key_rsa_pub: https://cs.nginx.com/static/keys/app-protect-security-updates.rsa.pub
 
 # Default NGINX Plus repositories
+nginx_plus_default_repository_alpine: https://pkgs.nginx.com/plus/alpine/v{{ ansible_distribution_version | regex_search('^[0-9]+\.[0-9]+') }}/main
+nginx_plus_default_repository_amazon: https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch
 nginx_plus_default_repository_debian: deb [arch=amd64 signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus
 nginx_plus_default_repository_redhat: https://pkgs.nginx.com/plus/centos/{{ ansible_distribution_major_version }}/$basearch/
-nginx_plus_default_repository_amazon: https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch
 
 # Default NGINX App Protect WAF repositories
+nginx_app_protect_waf_default_repository_amazon: https://pkgs.nginx.com/app-protect/centos/7/$basearch/
 nginx_app_protect_waf_default_repository_debian: deb [arch=amd64 signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/app-protect/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus
 nginx_app_protect_waf_default_repository_redhat: https://pkgs.nginx.com/app-protect/centos/{{ ansible_distribution_major_version }}/$basearch/
-nginx_app_protect_waf_default_repository_amazon: https://pkgs.nginx.com/app-protect/centos/7/$basearch/
 
 # Default NGINX App Protect WAF Security Updates repositories
+nginx_app_protect_waf_security_updates_default_repository_amazon: https://pkgs.nginx.com/app-protect-security-updates/centos/7/$basearch/
 nginx_app_protect_waf_security_updates_default_repository_debian: deb [arch=amd64 signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/app-protect-security-updates/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus
 nginx_app_protect_waf_security_updates_default_repository_redhat: https://pkgs.nginx.com/app-protect-security-updates/centos/{{ ansible_distribution_major_version }}/$basearch/
-nginx_app_protect_waf_security_updates_default_repository_amazon: https://pkgs.nginx.com/app-protect-security-updates/centos/7/$basearch/
 
 # Default NGINX App Protect DoS repositories
+nginx_app_protect_dos_default_repository_alpine: https://pkgs.nginx.com/app-protect-dos/alpine/v{{ ansible_distribution_version | regex_search('^[0-9]+\.[0-9]+') }}/main
 nginx_app_protect_dos_default_repository_debian: deb [arch=amd64 signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/app-protect-dos/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus
 nginx_app_protect_dos_default_repository_redhat: https://pkgs.nginx.com/app-protect-dos/centos/{{ ansible_distribution_major_version }}/$basearch/


### PR DESCRIPTION
### Proposed changes

* Add support for Alpine Linux for NGINX App Protect DoS.
* Add support for Debian bullseye for NGINX App Protect DoS.
* Check NGINX App Protect license is valid before trying to install NGINX App Protect (this means the role now requires the `community.crypto` collection).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
