### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,8 +3,8 @@ collections:
   - name: ansible.posix
     version: 1.4.0
   - name: community.crypto
-    version: 2.5.0
-  - name: community.docker
-    version: 3.1.0
+    version: 2.10.0
   - name: community.general
-    version: 5.5.0
+    version: 6.2.0
+  - name: community.docker  # Only required if you plan to use Molecule
+    version: 3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.2 (Unreleased)
 
+ENHANCEMENTS:
+
+Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.
+
 BUG FIXES:
 
 The Alpine Linux `libelf` dependency is no longer automatically installed by NGINX App Protect DoS so we need to explicitly install it as a prerequisite.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If you wish to install NGINX App Protect WAF or NGINX App Protect DoS using this
       - name: ansible.posix
         version: 1.4.0
       - name: community.crypto
-        version: 2.5.0
+        version: 2.10.0
       - name: community.general
-        version: 5.5.0
+        version: 6.2.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 3.1.0
+        version: 3.4.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
