### PR TITLE
Use `amd64` platform for Molecule tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The Alpine Linux `libelf` dependency is no longer automatically installed by NGI
 
 TESTS:
 
-Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
+* Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
+* Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
 
 ## 0.8.1 (September 28, 2022)
 

--- a/molecule/advanced/molecule.yml
+++ b/molecule/advanced/molecule.yml
@@ -11,6 +11,7 @@ lint: |
 platforms:
   - name: test-workload
     image: nginxdemos/hello
+    platform: amd64
     privileged: true
     groups:
       - workload
@@ -19,6 +20,7 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
+    platform: amd64
     privileged: true
     cgroupns_mode: host
     volumes:
@@ -30,6 +32,7 @@ platforms:
       - name: molecule-test
   - name: debian-buster
     image: debian:buster-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -42,6 +45,7 @@ platforms:
       - name: molecule-test
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,6 +58,7 @@ platforms:
       - name: molecule-test
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,7 @@ lint: |
 platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -15,6 +16,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -23,6 +25,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -31,6 +34,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: registry.access.redhat.com/ubi8/ubi:8.5
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -39,6 +43,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-buster
     image: debian:buster-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +52,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,6 +61,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/dos/molecule.yml
+++ b/molecule/dos/molecule.yml
@@ -7,6 +7,7 @@ lint: |
 platforms:
   - name: alpine-3.15
     image: alpine:3.15
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -15,6 +16,7 @@ platforms:
     command: /sbin/init
   - name: centos-7
     image: centos:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -23,6 +25,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -31,6 +34,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: registry.access.redhat.com/ubi8/ubi:8.5
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -39,6 +43,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-buster
     image: debian:buster-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +52,7 @@ platforms:
     command: /sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,6 +61,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,6 +70,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/specific-version/molecule.yml
+++ b/molecule/specific-version/molecule.yml
@@ -7,6 +7,7 @@ lint: |
 platforms:
   - name: centos-7
     image: centos:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -15,6 +16,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -23,6 +25,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-buster
     image: debian:buster-slim
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -31,6 +34,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -39,6 +43,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -7,6 +7,7 @@ lint: |
 platforms: # Ubuntu bionic and Debian buster result in a segmentation fault error as of Ansible core 2.13
   - name: centos-7
     image: centos:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -15,6 +16,7 @@ platforms: # Ubuntu bionic and Debian buster result in a segmentation fault erro
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -23,6 +25,7 @@ platforms: # Ubuntu bionic and Debian buster result in a segmentation fault erro
     command: /usr/sbin/init
   - name: rhel-8
     image: registry.access.redhat.com/ubi8/ubi:8.5
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -31,6 +34,7 @@ platforms: # Ubuntu bionic and Debian buster result in a segmentation fault erro
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
### Proposed changes

Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
