### PR TITLE
Refactor how supported distributions are checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 FEATURES:
 
-Refactor how this role checks if your distribution is supported NGINX App Protect. The role will no longer fail if the distros are not supported, you will instead get a warning. This should help with the ocassional lag between new releases of distributions and/or NGINX App Protect and this role being updated to support those releases.
+Refactor how this role checks if your distribution is supported NGINX App Protect. The role will no longer fail if the  target distribution is not supported, instead, you will get a warning. This should help with the occasional lag between new releases of distributions and/or NGINX App Protect and this role being updated to support those releases.
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.2 (Unreleased)
 
+FEATURES:
+
+Refactor how this role checks if your distribution is supported NGINX App Protect. The role will no longer fail if the distros are not supported, you will instead get a warning. This should help with the ocassional lag between new releases of distributions and/or NGINX App Protect and this role being updated to support those releases.
+
 ENHANCEMENTS:
 
 Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.

--- a/tasks/common/prerequisites/validate-supported-os.yml
+++ b/tasks/common/prerequisites/validate-supported-os.yml
@@ -28,5 +28,5 @@
     msg: NGINX App Protect cannot be installed on {{ ansible_distribution }} {{ ansible_distribution_version }} without setting the 'nginx_app_protect_use_rhel_subscription_repos' variable
   when:
     - ansible_distribution == "RedHat"
-    - ansible_distribution_version is version('7', '>')
+    - ansible_distribution_major_version is version('7', '>')
     - not nginx_app_protect_use_rhel_subscription_repos | bool

--- a/tasks/common/prerequisites/validate-supported-os.yml
+++ b/tasks/common/prerequisites/validate-supported-os.yml
@@ -1,51 +1,32 @@
 ---
-- name: (WAF) Set supported_os_waf when platform and major/minor version are in the WAF supported platforms dictionary
-  when: nginx_app_protect_waf_enable | bool and nginx_app_protect_waf_state != "absent"
-  block:
-    - name: (WAF) Set fact to true if item present in dictionary
-      ansible.builtin.set_fact:
-        supported_os_waf: true
-      when:
-        - ansible_distribution | lower in item.key
-        - ansible_distribution_version | regex_search('\\d+\\.?\\d*') in item.value
-      loop: "{{ query('dict', nginx_app_protect_waf_linux_families) }}"
+- name: (WAF) Check whether you are using a supported NGINX App Protect WAF distribution
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution | lower in nginx_app_protect_waf_linux_families.keys() | list
+      - ansible_distribution_version | regex_search('\\d+\\.?\\d*') in nginx_app_protect_waf_linux_families[ansible_distribution | lower]
+    success_msg: Your distribution, {{ ansible_distribution }} {{ ansible_distribution_version }}, is supported by NGINX App Protect WAF
+    fail_msg: Your distribution, {{ ansible_distribution }} {{ ansible_distribution_version }}, is not supported by NGINX App Protect WAF
+  when:
+    - nginx_app_protect_waf_enable | bool
+    - nginx_app_protect_waf_state != "absent"
+  ignore_errors: true # noqa ignore-errors
 
-    - name: (WAF) Set supported_os_waf to false if fact not defined
-      ansible.builtin.set_fact:
-        supported_os_waf: false
-      when: supported_os_waf is not defined
+- name: (DoS) Check whether you are using a supported NGINX App Protect DoS distribution
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution | lower in nginx_app_protect_dos_linux_families.keys() | list
+      - ansible_distribution_version | regex_search('\\d+\\.?\\d*') in nginx_app_protect_dos_linux_families[ansible_distribution | lower]
+    success_msg: Your distribution, {{ ansible_distribution }} {{ ansible_distribution_version }}, is supported by NGINX App Protect DoS
+    fail_msg: Your distribution, {{ ansible_distribution }} {{ ansible_distribution_version }}, is not supported by NGINX App Protect DoS
+  when:
+    - nginx_app_protect_dos_enable | bool
+    - nginx_app_protect_dos_state != "absent"
+  ignore_errors: true # noqa ignore-errors
 
-    - name: (WAF) Abort if the OS / version combination is not supported
-      ansible.builtin.fail:
-        msg: NGINX App Protect WAF is not supported on OS family {{ ansible_distribution }} version {{ ansible_distribution_version }}
-      when: not supported_os_waf
-
-- name: (DoS) Set supported_os_dos when platform and major/minor version are in the DoS supported platforms dictionary
-  when: nginx_app_protect_dos_enable | bool and nginx_app_protect_dos_state != "absent"
-  block:
-    - name: (DoS) Set fact to true if item present in dictionary
-      ansible.builtin.set_fact:
-        supported_os_dos: true
-      when:
-        - ansible_distribution | lower in item.key
-        - ansible_distribution_version | regex_search('\\d+\\.?\\d+') in item.value
-      loop: "{{ query('dict', nginx_app_protect_dos_linux_families) }}"
-
-    - name: (DoS) Set supported_os_dos to false if fact not defined
-      ansible.builtin.set_fact:
-        supported_os_dos: false
-      when: supported_os_dos is not defined
-
-    - name: (DoS) Abort if the OS / version combination is not supported
-      ansible.builtin.fail:
-        msg: NGINX App Protect DoS is not supported on OS family {{ ansible_distribution }} version {{ ansible_distribution_version }}
-      when: not supported_os_dos
-
-- name: Abort if installing on RHEL > 7 without subscription details
+- name: Abort if installing NGINX App Protect on RHEL >7 without subscription details
   ansible.builtin.fail:
-    msg: NGINX App Protect cannot be installed on OS family {{ ansible_distribution }} version {{ ansible_distribution_version }} without setting the 'nginx_app_protect_use_rhel_subscription_repos'
-      variable
+    msg: NGINX App Protect cannot be installed on {{ ansible_distribution }} {{ ansible_distribution_version }} without setting the 'nginx_app_protect_use_rhel_subscription_repos' variable
   when:
     - ansible_distribution == "RedHat"
-    - ansible_distribution_version | int > 7
+    - ansible_distribution_version is version('7', '>')
     - not nginx_app_protect_use_rhel_subscription_repos | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,35 @@
 ---
-- name: Check if OS is supported for NGINX App Protect WAF or DoS install
+- name: Check whether you are using a supported NGINX App Protect distribution
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/common/prerequisites/validate-supported-os.yml"
   when: nginx_app_protect_waf_state != "absent"
         or nginx_app_protect_dos_state != "absent"
+  tags: nginx_app_protect_check_support
 
-- name: Fail if variables for 'nginx_app_protect_security_policy_file_enable' are not defined
+- name: Check if the variables for 'nginx_app_protect_security_policy_file_enable' are defined
   ansible.builtin.assert:
     that:
       - "{{ item }} is defined"
       - "{{ item }} | length > 0"
+    fail_msg: If you want to publish a security policy file, don't forget to define at least one 'src' and 'dest' variables
   loop:
     - nginx_app_protect_security_policy_file.0.src
     - nginx_app_protect_security_policy_file.0.dest
   when: nginx_app_protect_security_policy_file_enable | bool
+  ignore_errors: true # noqa ignore-errors
+  tags: nginx_app_protect_check_policy_file
 
-- name: Fail if variables for 'nginx_app_protect_log_policy_file_enable' are not defined
+- name: Check if the variables for 'nginx_app_protect_log_policy_file_enable' are defined
   ansible.builtin.assert:
     that:
       - "{{ item }} is defined"
       - "{{ item }} | length > 0"
+    fail_msg: If you want to publish a log policy file, don't forget to define at least one 'src' and 'dest' variables
   loop:
     - nginx_app_protect_log_policy_file.0.src
     - nginx_app_protect_log_policy_file.0.dest
   when: nginx_app_protect_log_policy_file_enable | bool
+  ignore_errors: true # noqa ignore-errors
+  tags: nginx_app_protect_check_policy_file
 
 - name: Install prerequisites
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/common/prerequisites/prerequisites.yml"


### PR DESCRIPTION
### Proposed changes

Refactor how this role checks if your distribution is supported NGINX App Protect. The role will no longer fail if the  target distribution is not supported, instead, you will get a warning. This should help with the occasional lag between new releases of distributions and/or NGINX App Protect and this role being updated to support those releases.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
