### PR TITLE
Bring CI/CD up to date and resolve minor Python 3 cryptography issue

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,6 @@ exclude_paths:
   - .github/
 offline: true
 skip_list:
-  - args[module]
   - name[template]
+  - schema[meta]
   - yaml[line-length]

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 ---
+exclude_paths:
+  - .github/
 offline: true
 skip_list:
   - args[module]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 ---
 name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
+include-pre-releases: true
 categories:
   - title: "💣 Breaking Changes"
     labels:

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,9 +13,36 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 jobs:
+  ansible-lint:
+    name: Ansible Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install Ansible Lint
+        run: pip3 install -r .github/workflows/requirements/requirements_ansible_lint.txt
+
+      - name: Install Ansible collection dependencies
+        run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
+
+      - name: Run Ansible Lint
+        run: ansible-lint --force-color
+
   molecule:
     name: Molecule
     runs-on: ubuntu-22.04
+    needs: ansible-lint
+    env:
+      NGINX_CRT: ${{ secrets.NGINX_CRT }}
+      NGINX_KEY: ${{ secrets.NGINX_KEY }}
+      RHEL_USERNAME: ${{ secrets.RHEL_USERNAME }}
+      RHEL_PASSWORD: ${{ secrets.RHEL_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,10 +54,10 @@ jobs:
           - uninstall
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
@@ -46,7 +73,4 @@ jobs:
         env:
           PY_COLORS: 1
           ANSIBLE_FORCE_COLOR: 1
-          NGINX_CRT: ${{ secrets.NGINX_CRT }}
-          NGINX_KEY: ${{ secrets.NGINX_KEY }}
-          RHEL_USERNAME: ${{ secrets.RHEL_USERNAME }}
-          RHEL_PASSWORD: ${{ secrets.RHEL_PASSWORD }}
+

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,10 +1,10 @@
 ---
 collections:
   - name: ansible.posix
-    version: 1.4.0
-  - name: community.crypto
-    version: 2.10.0
+    version: 1.5.4
   - name: community.general
-    version: 6.2.0
+    version: 6.4.0
+  - name: community.crypto
+    version: 2.14.1
   - name: community.docker # Only required if you plan to use Molecule
-    version: 3.4.0
+    version: 3.4.7

--- a/.github/workflows/requirements/requirements_ansible_lint.txt
+++ b/.github/workflows/requirements/requirements_ansible_lint.txt
@@ -1,0 +1,5 @@
+ansible-core==2.16.2
+jinja2==3.1.3
+ansible-compat==4.1.11
+yamllint==1.33.0
+ansible-lint==6.22.1

--- a/.github/workflows/requirements/requirements_galaxy.txt
+++ b/.github/workflows/requirements/requirements_galaxy.txt
@@ -1,1 +1,1 @@
-ansible-core==2.14.4
+ansible-core==2.16.2

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,7 +1,6 @@
-ansible-core==2.14.4
-Jinja2==3.1.2
-ansible-lint==6.15.0
-yamllint==1.30.0
-molecule==4.0.4
-molecule-plugins[docker]==23.0.0
-docker==6.0.1
+ansible-core==2.16.2
+jinja2==3.1.3
+ansible-compat==4.1.11
+molecule==6.0.3
+molecule-plugins[docker]==23.5.0
+docker==7.0.0

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -2,5 +2,6 @@ ansible-core==2.14.4
 Jinja2==3.1.2
 ansible-lint==6.14.3
 yamllint==1.30.0
-molecule[docker]==4.0.4
+molecule==4.0.4
+molecule-plugins[docker]==23.0.0
 docker==6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 0.9.1 (Unreleased)
 
+ENHANCEMENTS:
+
+- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.4.0`, `community.crypto` collection to `2.14.1` and `community.docker` collection to `3.4.7`.
+- Oracle Linux 8 requires the Python `python3.11-cryptography` package for validating the NGINX App Protect repository certificate.
+
 CI/CD:
 
+- Split Ansible Lint into its own GitHub Actions job since Molecule no longer runs linters natively.
 - Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
 - Add pre-releases to Release Drafter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.1 (Unreleased)
+
+CI/CD:
+
+- Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
+- Add pre-releases to Release Drafter.
+
 ## 0.9.0 (January 29, 2023)
 
 FEATURES:

--- a/molecule/advanced/molecule.yml
+++ b/molecule/advanced/molecule.yml
@@ -5,9 +5,6 @@ dependency:
     role-file: molecule/advanced/requirements.yml
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: test-workload
     image: nginxdemos/hello

--- a/molecule/common/cleanup.yml
+++ b/molecule/common/cleanup.yml
@@ -9,12 +9,11 @@
           ansible.builtin.wait_for_connection:
             delay: 1
             timeout: 2
-          register: connection
-          ignore_errors: true
+          register: container
 
         - name: Containers are not up, quit from here
           ansible.builtin.fail:
-          when: connection.failed
+          when: container['failed'] | bool
 
         - name: Gather facts
           ansible.builtin.setup:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: amazonlinux-2
     image: amazonlinux:2

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -59,4 +59,4 @@
 
     - name: Ensure /etc/app_protect/conf/test-security-profile.json exists
       ansible.builtin.assert:
-        that: log_profile.stat.exists | bool
+        that: log_profile['stat']['exists'] | bool

--- a/molecule/dos/molecule.yml
+++ b/molecule/dos/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: alpine-3.15
     image: alpine:3.15

--- a/molecule/specific-version/molecule.yml
+++ b/molecule/specific-version/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: amazonlinux-2
     image: amazonlinux:2

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible core 2.13
   - name: centos-7
     image: centos:7

--- a/tasks/common/install/setup-license.yml
+++ b/tasks/common/install/setup-license.yml
@@ -66,6 +66,14 @@
     - name: (Debian/Red Hat OSs) Install cryptography package
       ansible.builtin.package:
         name: "{{ (ansible_python['version']['major'] == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
+      when: not (ansible_facts['distribution'] == "OracleLinux" and ansible_facts['distribution_major_version'] == "8")
+
+    - name: (OracleLinux 8) Install cryptography package
+      ansible.builtin.package:
+        name: "python3.11-cryptography"
+      when:
+        - ansible_facts['distribution'] == "OracleLinux"
+        - ansible_facts['distribution_major_version'] == "8"
 
     - name: (Debian/Red Hat OSs) Check that NGINX App Protect WAF/DoS certificate is valid
       community.crypto.x509_certificate_info:


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.4.0`, `community.crypto` collection to `2.14.1` and `community.docker` collection to `3.4.7`.
- Oracle Linux 8 requires the Python `python3.11-cryptography` package for validating the NGINX App Protect repository certificate.

CI/CD:

- Split Ansible Lint into its own GitHub Actions job since Molecule no longer runs linters natively.
- Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
- Add pre-releases to Release Drafter.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
