### PR TITLE
chore!: Remove support for RHEL 7 based distributions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Main global owner #
 #####################
-* @alessfg @aknot242
+* @alessfg
 /.github/workflows/
 *.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ BREAKING CHANGES:
 FEATURES:
 
 - Add support for installing NGINX App Protect WAF on Alpine Linux 3.17, RHEL 9, and Ubuntu jammy.
-- Remove support for installing NGINX App Protect WAF/DoS on Ubuntu bionic.
+- Remove support for installing NGINX App Protect WAF/DoS on Alpine Linux 3.15/3.16 and Ubuntu bionic.
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 0.9.1 (Unreleased)
+## 0.10.0 (Unreleased)
+
+BREAKING CHANGES:
+
+- Remove support for RHEL 7 based distributions (RHEL/CentOS/Oracle Linux 7). CentOS 7 has reached EoL, RHEL 7 has reached EoM, and Oracle Linux 7 will reach EoL shortly. These distributions will not be supported by new NGINX App Protect releases moving forward. If you are still using one of these distributions, please consider upgrading. If you still want to use this role for the time being, please use the previous release (0.9.0). Do note that you will only be able to use NGINX App Protect versions released as of the date of the aforementioned release (January 29, 2023).
 
 FEATURES:
 
-- Add support for installing NGINX App Protect WAF on Alpine Linux 3.16/3.17, RHEL 9, and Ubuntu jammy.
-- Remove support for installing NGINX App Protect WAF on Ubuntu bionic.
+- Add support for installing NGINX App Protect WAF on Alpine Linux 3.17, RHEL 9, and Ubuntu jammy.
+- Remove support for installing NGINX App Protect WAF/DoS on Ubuntu bionic.
 
 ENHANCEMENTS:
 
@@ -44,7 +48,7 @@ BUG FIXES:
 TESTS:
 
 - Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
-- Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
+- Explicitly specify `x86_64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
 
 ## 0.8.1 (September 28, 2022)
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,9 @@ The NGINX App Protect Ansible role supports all platforms supported by [NGINX Pl
 ```yaml
 Amazon Linux 2:
   - any
-CentOS:
-  - 7.4+
 Debian:
   - buster (10)
 RHEL:
-  - 7.4+
   - 8.1+
 Ubuntu:
   - bionic (18.04)
@@ -108,15 +105,10 @@ Ubuntu:
 The NGINX App Protect Ansible role supports all platforms supported by [NGINX Plus](https://www.nginx.com/products/technical-specs/) that intersect with the following list of distributions of App Protect DoS:
 
 ```yaml
-Alpine:
-  - 3.15
-CentOS:
-  - 7.4+
 Debian:
   - buster (10)
   - bullseye (11)
 RHEL:
-  - 7.4+
   - 8.0+
 Ubuntu:
   - bionic (18.04)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,7 +112,7 @@ nginx_app_protect_log_policy_file:
   - src: files/config/log-policy.json
     dest: /etc/app_protect/conf/log-policy.json
 
-# Set SELinux enforcing for NGINX (CentOS/Red Hat only) - you may need to open ports on your own
+# Set SELinux enforcing for NGINX (Red Hat only) - you may need to open ports on your own
 nginx_app_protect_selinux: false
 
 # Enable enforcing mode if true.  Permissive if false (audit only, no enforcing) globally (only works with nginx_selinux: true)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
     - name: Debian
       versions: [bullseye]
     - name: EL
-      versions: ['7', '8', '9']
+      versions: ['8', '9']
     - name: OracleLinux
       versions: ['8']
     - name: Ubuntu

--- a/molecule/advanced/molecule.yml
+++ b/molecule/advanced/molecule.yml
@@ -8,54 +8,15 @@ driver:
 platforms:
   - name: test-workload
     image: nginxdemos/hello
-    platform: amd64
+    platform: x86_64
     privileged: true
     groups:
       - workload
     networks:
       - name: molecule-test
-  - name: centos-7
-    image: centos:7
-    dockerfile: ../common/Dockerfile.j2
-    platform: amd64
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-    groups:
-      - nap
-    networks:
-      - name: molecule-test
-  - name: debian-buster
-    image: debian:buster-slim
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
-    groups:
-      - nap
-    networks:
-      - name: molecule-test
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
-    groups:
-      - nap
-    networks:
-      - name: molecule-test
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -25,8 +25,7 @@ RUN \
     && dnf clean all; \
   elif [ $(command -v yum) ]; then \
     yum makecache fast \
-    && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
-    && yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-copr-1.1.31-54.el7_8.noarch.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm \
+    && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-copr yum-plugin-ovl \
     && yum copr enable -y jsynacek/systemd-backports-for-centos-7 \
     && yum update --disableplugin=priorities -y systemd \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,18 +2,9 @@
 driver:
   name: docker
 platforms:
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -22,16 +13,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: centos-7
-    image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -40,7 +22,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -49,16 +31,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: rhel-7
-    image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -67,7 +40,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -78,7 +51,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     env:
       SMDEV_CONTAINER_OFF: "1"
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -87,7 +60,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -96,7 +69,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/dos/molecule.yml
+++ b/molecule/dos/molecule.yml
@@ -2,63 +2,27 @@
 driver:
   name: docker
 platforms:
-  - name: alpine-3.15
-    image: alpine:3.15
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
-  - name: centos-7
-    image: centos:7
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: rhel-7
-    image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/specific-version/molecule.yml
+++ b/molecule/specific-version/molecule.yml
@@ -4,16 +4,7 @@ driver:
 platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: centos-7
-    image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -22,7 +13,7 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -31,34 +22,16 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: rhel-7
-    image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -2,36 +2,18 @@
 driver:
   name: docker
 platforms:
-  - name: centos-7
-    image: centos:7
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: rhel-7
-    image: registry.access.redhat.com/ubi7/ubi:7.9
-    platform: amd64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
   - name: rhel-8
     image: registry.access.redhat.com/ubi8/ubi:8.5
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -40,7 +22,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/tasks/common/keys/setup-keys.yml
+++ b/tasks/common/keys/setup-keys.yml
@@ -38,14 +38,14 @@
         url: "{{ nginx_app_protect_waf_signing_key['waf_security_updates'] | default(nginx_app_protect_waf_security_updates_default_signing_key_pgp) }}"
       when: nginx_app_protect_waf_enable | bool
 
-- name: (Amazon Linux/CentOS/RHEL) Set up NGINX App Protect and security updates signing key
+- name: (Amazon Linux/RHEL) Set up NGINX App Protect and security updates signing key
   when: ansible_facts['os_family'] == "RedHat"
   block:
-    - name: (CentOS/RHEL) Add NGINX WAF/DoS signing key
+    - name: (RHEL) Add NGINX WAF/DoS signing key
       ansible.builtin.rpm_key:
         key: "{{ nginx_app_protect_signing_key['nginx_plus'] | default(nginx_app_protect_default_signing_key_pgp) }}"
 
-    - name: (Amazon Linux/CentOS/RHEL) Add NGINX App Protect WAF security updates signing key
+    - name: (Amazon Linux/RHEL) Add NGINX App Protect WAF security updates signing key
       ansible.builtin.rpm_key:
         key: "{{ nginx_app_protect_waf_signing_key['waf_security_updates'] | default(nginx_app_protect_waf_security_updates_default_signing_key_pgp) }}"
       when: nginx_app_protect_waf_enable | bool

--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -19,71 +19,32 @@
   loop: "{{ nginx_app_protect_amazon_extras }}"
   when: ansible_facts['distribution'] == "Amazon"
 
-- name: (Amazon Linux/CentOS/RHEL) Install package dependencies
+- name: (Amazon Linux/RHEL) Install package dependencies
   when: ansible_facts['os_family'] == "RedHat"
   block:
-    - name: (Amazon Linux/CentOS/RHEL) Import EPEL GPG key
+    - name: (Amazon Linux/RHEL) Import EPEL GPG key
       ansible.builtin.rpm_key:
         state: present
         key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ (ansible_facts['distribution'] == 'Amazon') | ternary('7', ansible_facts['distribution_major_version']) }}
 
-    - name: (Amazon Linux/CentOS/RHEL) Install package dependencies
+    - name: (Amazon Linux/RHEL) Install package dependencies
       ansible.builtin.yum:
         name: "{{ nginx_app_protect_redhat_dependencies }}"
         update_cache: true
         state: latest # noqa package-latest
 
 - name: (RHEL) Set up RHEL specific repositories
-  when: ansible_facts['distribution'] == "RedHat"
+  when:
+    - ansible_facts['distribution'] == "RedHat"
+    - nginx_app_protect_use_rhel_subscription_repos | bool
   block:
-    - name: (RHEL 7) Set up RHEL dependencies from OSS repositories
-      ansible.builtin.yum_repository:
-        name: centos
-        description: NGINX App Protect dependencies
-        baseurl: https://ftp.heanet.ie/pub/centos/7/os/$basearch/
-        enabled: true
-        gpgcheck: true
-        gpgkey: https://ftp.heanet.ie/pub/centos/7/os/$basearch/RPM-GPG-KEY-CentOS-7
-        state: "{{ nginx_app_protect_license_status | default('present') }}"
-      when:
-        - ansible_facts['distribution_major_version'] is version('7', '==')
-        - not nginx_app_protect_use_rhel_subscription_repos | bool
-
-    - name: (RHEL 7 DoS) Set up RHEL NGINX App Protect DoS dependencies from OSS repositories
-      ansible.builtin.yum_repository:
-        name: extras
-        description: NGINX App Protect DoS dependencies
-        mirrorlist: http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras
-        enabled: true
-        gpgcheck: true
-        gpgkey: http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
-        state: "{{ nginx_app_protect_license_status | default('present') }}"
-      when:
-        - ansible_facts['distribution_major_version'] is version('7', '==')
-        - not nginx_app_protect_use_rhel_subscription_repos | bool
-        - nginx_app_protect_dos_enable | bool
-
     - name: (RHEL) Enable RHEL subscription manager repos management
       ansible.builtin.command: subscription-manager config --rhsm.manage_repos=1
       changed_when: false
-      when: nginx_app_protect_use_rhel_subscription_repos | bool
 
-    - name: (RHEL 7) Set up RHEL dependencies from RHEL official repositories
-      community.general.rhsm_repository:
-        name:
-          - rhel-7-server-optional-rpms
-          - rhel-7-server-extras-rpms
-          - rhel-ha-for-rhel-7-server-rpms
-      when:
-        - ansible_facts['distribution_major_version'] is version('7', '==')
-        - nginx_app_protect_use_rhel_subscription_repos | bool
-
-    - name: (RHEL 8/9) Set up RHEL dependencies from RHEL official repositories
+    - name: (RHEL) Set up RHEL dependencies from RHEL official repositories
       community.general.rhsm_repository:
         name: codeready-builder-for-rhel-{{ ansible_facts['distribution_major_version'] }}-x86_64-rpms
-      when:
-        - ansible_facts['distribution_major_version'] is version('8', '>=')
-        - nginx_app_protect_use_rhel_subscription_repos | bool
 
 - name: (Oracle Linux) Set up Oracle Linux specific repositories
   community.general.ini_file:

--- a/tasks/common/prerequisites/setup-selinux.yml
+++ b/tasks/common/prerequisites/setup-selinux.yml
@@ -1,5 +1,5 @@
 ---
-- name: (CentOS/RHEL) Install dependencies
+- name: (RHEL) Install dependencies
   ansible.builtin.yum:
     name:
       - libselinux-utils

--- a/tasks/common/validate/validate.yml
+++ b/tasks/common/validate/validate.yml
@@ -30,7 +30,6 @@
     msg: NGINX App Protect cannot be installed on Red Hat Enterprise Linux {{ ansible_facts['distribution_version'] }} without a valid Red Hat Enterprise Linux subscription. Subscribe your target environment before running the role and then set the 'nginx_app_protect_use_rhel_subscription_repos' variable to true.
   when:
     - ansible_facts['distribution'] == "RedHat"
-    - ansible_facts['distribution_major_version'] is version('7', '>')
     - not nginx_app_protect_use_rhel_subscription_repos | bool
   ignore_errors: true # noqa ignore-errors
 

--- a/tasks/dos/install-redhat.yml
+++ b/tasks/dos/install-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: (CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
+- name: (RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
   ansible.builtin.yum_repository:
     name: nginx-plus
     description: NGINX Plus repository
@@ -12,7 +12,7 @@
     mode: "0644"
   when: nginx_app_protect_dos_manage_repo | bool
 
-- name: (CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect DoS repository
+- name: (RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect DoS repository
   ansible.builtin.yum_repository:
     name: nginx-app-protect-dos
     description: NGINX App Protect DoS repository
@@ -25,11 +25,11 @@
     mode: "0644"
   when: nginx_app_protect_dos_manage_repo | bool
 
-- name: (CentOS/RHEL) Force Yum cache refresh
+- name: (RHEL) Force Yum cache refresh
   ansible.builtin.command: yum clean metadata
   changed_when: false
 
-- name: (CentOS/RHEL) {{ nginx_app_protect_dos_setup | capitalize }} NGINX App Protect DoS
+- name: (RHEL) {{ nginx_app_protect_dos_setup | capitalize }} NGINX App Protect DoS
   ansible.builtin.yum:
     name: app-protect-dos{{ (nginx_app_protect_dos_state == 'absent') | ternary(',nginx-plus-module-appprotectdos', '') }}
     state: "{{ nginx_app_protect_dos_state }}"

--- a/tasks/waf/install-redhat.yml
+++ b/tasks/waf/install-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
   ansible.builtin.yum_repository:
     name: nginx-plus
     description: NGINX Plus repository
@@ -12,7 +12,7 @@
     mode: "0644"
   when: nginx_app_protect_waf_manage_repo | bool
 
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect WAF repository
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect WAF repository
   ansible.builtin.yum_repository:
     name: nginx-app-protect
     description: NGINX App Protect WAF repository
@@ -25,7 +25,7 @@
     mode: "0644"
   when: nginx_app_protect_waf_manage_repo | bool
 
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect WAF security updates repository
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_license_status is defined | ternary('Remove', 'Configure') }} NGINX App Protect WAF security updates repository
   ansible.builtin.yum_repository:
     name: nginx-app-protect-security-updates
     description: NGINX App Protect WAF security updates repository
@@ -40,11 +40,11 @@
     - (nginx_app_protect_waf_install_signatures | bool) or (nginx_app_protect_waf_install_threat_campaigns | bool)
     - nginx_app_protect_waf_manage_repo | bool
 
-- name: (Amazon Linux/CentOS/RHEL) Force Yum cache refresh
+- name: (Amazon Linux/RHEL) Force Yum cache refresh
   ansible.builtin.command: yum clean metadata
   changed_when: false
 
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF
   ansible.builtin.yum:
     name: app-protect{{ (nginx_app_protect_waf_state == 'absent') | ternary(',app-protect-compiler,app-protect-engine,app-protect-plugin,nginx-plus-module-appprotect', '') }}
     state: "{{ nginx_app_protect_waf_state }}"
@@ -53,7 +53,7 @@
   when: nginx_app_protect_license_status is not defined
   notify: (Handler - NGINX App Protect) Run NGINX
 
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF signatures {{ nginx_app_protect_waf_signatures_version is defined | ternary(nginx_app_protect_signatures_version, '') }}
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF signatures {{ nginx_app_protect_waf_signatures_version is defined | ternary(nginx_app_protect_signatures_version, '') }}
   ansible.builtin.yum:
     name: app-protect-attack-signatures{{ nginx_app_protect_waf_signatures_version | default('') }}
     state: "{{ nginx_app_protect_waf_state }}"
@@ -65,7 +65,7 @@
     - nginx_app_protect_waf_license_status is not defined
   notify: (Handler - NGINX App Protect) Run NGINX
 
-- name: (Amazon Linux/CentOS/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF threat campaigns {{ nginx_app_protect_waf_threat_campaigns_version is defined | ternary(nginx_app_protect_threat_campaigns_version, '') }}
+- name: (Amazon Linux/RHEL) {{ nginx_app_protect_waf_setup | capitalize }} NGINX App Protect WAF threat campaigns {{ nginx_app_protect_waf_threat_campaigns_version is defined | ternary(nginx_app_protect_threat_campaigns_version, '') }}
   ansible.builtin.yum:
     name: app-protect-threat-campaigns{{ nginx_app_protect_waf_threat_campaigns_version | default('') }}
     state: "{{ nginx_app_protect_waf_state }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,15 +18,11 @@ nginx_app_protect_dos_state: "{{ nginx_app_protect_state_vals[nginx_app_protect_
 nginx_app_protect_waf_distributions:
   alpine:
     name: Alpine Linux
-    versions: [3.16, 3.17]
+    versions: [3.17]
     architectures: [x86_64]
   amazon:
     name: Amazon Linux
     versions: [2]
-    architectures: [x86_64]
-  centos:
-    name: CentOS
-    versions: [7]
     architectures: [x86_64]
   debian:
     name: Debian
@@ -38,7 +34,7 @@ nginx_app_protect_waf_distributions:
     architectures: [x86_64]
   redhat:
     name: Red Hat Enterprise Linux
-    versions: [7, 8, 9]
+    versions: [8, 9]
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
@@ -47,25 +43,17 @@ nginx_app_protect_waf_distributions:
 
 # Supported NGINX App Protect DoS distributions
 nginx_app_protect_dos_distributions:
-  alpine:
-    name: Alpine Linux
-    versions: [3.15]
-    architectures: [x86_64]
-  centos:
-    name: CentOS
-    versions: [7]
-    architectures: [x86_64]
   debian:
     name: Debian
     versions: [11]
     architectures: [x86_64]
   redhat:
     name: Red Hat Enterprise Linux
-    versions: [7, 8]
+    versions: [8]
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [18.04, 20.04]
+    versions: [20.04]
     architectures: [x86_64]
 
 # Alpine Linux dependencies


### PR DESCRIPTION
### Proposed changes

- Remove support for RHEL 7 based distributions (RHEL/CentOS/Oracle Linux 7) given CentOS 7 has reached EoL, RHEL 7 has reached EoM, and Oracle Linux 7 will reach EoL shortly.
- Remove support for installing NGINX App Protect WAF/DoS on Alpine Linux 3.15/3.16 and Ubuntu bionic.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
