### PR TITLE
fix: EPEL is no longer active on RHEL 7 based distros

### DIFF
--- a/tasks/common/prerequisites/install-dependencies.yml
+++ b/tasks/common/prerequisites/install-dependencies.yml
@@ -13,23 +13,38 @@
     state: latest # noqa package-latest
   when: ansible_facts['os_family'] == "Debian"
 
+- name: (Amazon Linux/RHEL) Install package dependencies
+  ansible.builtin.yum:
+    name: "{{ nginx_app_protect_redhat_dependencies }}"
+    update_cache: true
+    state: latest # noqa package-latest
+  when: ansible_facts['os_family'] == "RedHat"
+
 - name: (Amazon Linux) Set up Amazon Linux Extras repositories
   ansible.builtin.command: amazon-linux-extras enable {{ item }}
   changed_when: false
   loop: "{{ nginx_app_protect_amazon_extras }}"
   when: ansible_facts['distribution'] == "Amazon"
 
-- name: (Amazon Linux/RHEL) Install package dependencies
-  when: ansible_facts['os_family'] == "RedHat"
+- name: (Amazon Linux) Install EPEL
+  ansible.builtin.command:
+    cmd: amazon-linux-extras install -y epel
+    creates: /etc/yum.repos.d/epel.repo
+  when: ansible_facts['distribution'] == "Amazon"
+
+- name: (RHEL) Install EPEL
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution'] != "Amazon"
   block:
-    - name: (Amazon Linux/RHEL) Import EPEL GPG key
+    - name: (RHEL) Import EPEL GPG key
       ansible.builtin.rpm_key:
         state: present
-        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ (ansible_facts['distribution'] == 'Amazon') | ternary('7', ansible_facts['distribution_major_version']) }}
+        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}
 
-    - name: (Amazon Linux/RHEL) Install package dependencies
+    - name: (RHEL) Install package dependencies
       ansible.builtin.yum:
-        name: "{{ nginx_app_protect_redhat_dependencies }}"
+        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
         update_cache: true
         state: latest # noqa package-latest
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -74,7 +74,7 @@ nginx_app_protect_amazon_extras: [selinux-ng]
 nginx_app_protect_debian_dependencies: [apt-transport-https, ca-certificates]
 
 # Red Hat dependencies
-nginx_app_protect_redhat_dependencies: [ca-certificates, "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ((ansible_facts['distribution'] == 'Amazon') | ternary('7', ansible_facts['distribution_major_version'])) }}.noarch.rpm"]
+nginx_app_protect_redhat_dependencies: [ca-certificates]
 
 # Choose where to fetch the NGINX App Protect and Security Updates signing keys from.
 # Default settings are the official NGINX signing key hosts.


### PR DESCRIPTION
### Proposed changes

The EPEL 7 repo is no longer active, so we need to update the Amazon Linux 2 EPEL task to use the Amazon Linux 2 EPEL extras repo instead.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main.yml`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/defaults/main.yml), [`README.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx-app-protect/blob/main/CHANGELOG.md))
